### PR TITLE
options.transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const webhooks = new WebhooksApi({
   secret: 'mysecret'
 })
 
-webhooks.on('*', (data, {id, name}) => {
+webhooks.on('*', ({id, name, payload}) => {
   console.log(name, 'event received')
 })
 
@@ -69,12 +69,24 @@ new WebhooksApi({secret[, path]})
   <tr>
     <td>
       <code>
+        transform
+      </code>
+      <em>(Function)</em>
+    </td>
+    <td>
+      Only relevant for <a href="#webhookson"><code>webhooks.on</code></a>.
+      Transform emitted event before calling handlers. Can be asynchronous.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
         path
       </code>
       <em>(String)</em>
     </td>
     <td>
-      Only relevant for <a href="#webhooksmiddleware"><code>middleware</code></a>.
+      Only relevant for <a href="#webhooksmiddleware"><code>webhooks.middleware</code></a>.
       Custom path to match requests against. Defaults to <code>/</code>.
     </td>
   </tr>
@@ -85,14 +97,14 @@ Returns the `webhooks` API.
 ### webhooks.sign()
 
 ```js
-weebhooks.sign(eventData)
+weebhooks.sign(eventPayload)
 ```
 
 <table width="100%">
   <tr>
     <td>
       <code>
-        data
+        eventPayload
       </code>
       <em>
         (Object)
@@ -100,26 +112,26 @@ weebhooks.sign(eventData)
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook request body as received from GitHub
+      Webhook request payload as received from GitHub
     </td>
   </tr>
 </table>
 
-Returns a `signature` string. Throws error if `data` is not passed.
+Returns a `signature` string. Throws error if `eventPayload` is not passed.
 
 Can also be used [standalone](sign/).
 
 ### webhooks.verify()
 
 ```js
-weebhooks.verify(eventData, signature)
+weebhooks.verify(eventPayload, signature)
 ```
 
 <table width="100%">
   <tr>
     <td>
       <code>
-        data
+        eventPayload
       </code>
       <em>
         (Object)
@@ -127,7 +139,7 @@ weebhooks.verify(eventData, signature)
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook event request body as received from GitHub.
+      Webhook event request payload as received from GitHub.
     </td>
   </tr>
   <tr>
@@ -146,14 +158,14 @@ weebhooks.verify(eventData, signature)
   </tr>
 </table>
 
-Returns `true` or `false`. Throws error if `data` or `signature` not passed.
+Returns `true` or `false`. Throws error if `eventPayload` or `signature` not passed.
 
 Can also be used [standalone](verify/).
 
 ### webhooks.receive()
 
 ```js
-webhooks.receive({name, data})
+webhooks.receive({id, name, payload})
 ```
 
 <table width="100%">
@@ -175,7 +187,7 @@ webhooks.receive({name, data})
   <tr>
     <td>
       <code>
-        data
+        payload
       </code>
       <em>
         Object
@@ -183,7 +195,7 @@ webhooks.receive({name, data})
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook event request body as received from GitHub.
+      Webhook event request payload as received from GitHub.
     </td>
   </tr>
 </table>
@@ -241,7 +253,7 @@ webhooks.on(eventNames, handler)
       <strong>Required.</strong>
       Method to be run each time the event with the passed name is received.
       the <code>handler</code> function can be an async function, throw an error or
-      return a Promise. The handler is called with two arguments: <code>data</code> (the event payload) and <code>{id, name}</code>.
+      return a Promise. The handler is called with an event object: <code>{id, name, payload}</code>.
     </td>
   </tr>
 </table>
@@ -628,8 +640,8 @@ Besides the webhook events, there are [special events](#specialevents) emitted b
 The `*` event is emitted for all webhook events [listed above](#listofwebhookevents).
 
 ```js
-webhooks.on('*', (eventPayload, eventMeta) => {
-  console.log(`"${eventMeta.name}" event received (id: ${eventMeta.id})"`)
+webhooks.on('*', (event) => {
+  console.log(`"${event.name}" event received (id: ${event.id})"`)
 })
 ```
 
@@ -639,7 +651,7 @@ If a webhook event handler throws an error or returns a promise that rejects, an
 
 - `id`: The unique webhook event request id
 - `name`: The name of the event
-- `data`: The event request payload
+- `payload`: The event request payload
 
 ```js
 webhooks.on('error', (error) => {

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ The `*` event is emitted for all webhook events [listed above](#listofwebhookeve
 
 ```js
 webhooks.on('*', (event) => {
-  console.log(`"${event.name}" event received (id: ${event.id})"`)
+  console.log(`"${event.name}" event received"`)
 })
 ```
 

--- a/event-handler/README.md
+++ b/event-handler/README.md
@@ -2,28 +2,41 @@
 
 If you implement the route to receive webhook events from GitHub yourself then you can use the `event-handler` as a standalone module
 
-🚨 Make sure to _always_ verify that the event request is coming from GitHub itself using the `eventHandler.verify(data, signature)` method.
-
 ## Example
 
 ```js
-const eventHandler = require('@octokit/webhooks/event-handler')({secret: 'mysecret'})
-
+const EventHandler = require('@octokit/webhooks/event-handler')
+const eventHandler = new EventHandler({
+  async transform (event) {
+    // optionally transform passed event before handlers are called
+    return event
+  }
+})
 eventHandler.on('installation', asyncInstallationHook)
 
 // put this inside your webhooks route handler
-if (!eventHandler.verify(options.data, request.headers['x-github-signature'])) {
+eventHandler.reiceive({
+  id: request.headers['x-github-delivery'],
+  name: request.headers['x-github-event'],
+  payload: request.body
+}).catch(handleErrorsFromHooks)
+```
+
+## 🚨 Verify events
+
+If you receive events through a publicly accessible URL, make sure to verify that the event request is coming from GitHub:
+
+```js
+const verify = require('@octokit/webhooks/verify')
+const secret = 'mysecret'
+
+if (!verify(secret, request.payload, request.headers['x-github-signature'])) {
   throw new Error('Signature does not match event payload & secret')
 }
-
-eventHandler.reiceive({
-  name: request.headers['x-github-event'],
-  data: request.body
-}).catch(handleErrorsFromHooks)
 ```
 
 ## API
 
-The `event-handler` API implements [`.sign()`](../#webhookssign), [`.verify()`](../#webhooksverify), [`.reiceive()`](../#webhooksreceive), [`.on()`](../#webhookson) and [`.removeListener()`](../#webhooksremovelistener).
+The `event-handler` API implements [`.reiceive()`](../#webhooksreceive), [`.on()`](../#webhookson) and [`.removeListener()`](../#webhooksremovelistener).
 
 Back to [@octokit/webhooks README](..).

--- a/event-handler/index.js
+++ b/event-handler/index.js
@@ -3,22 +3,17 @@ module.exports = createEventHandler
 const on = require('./on')
 const receive = require('./receive')
 const removeListener = require('./remove-listener')
-const sign = require('../sign')
-const verify = require('../verify')
 
 function createEventHandler (options) {
-  if (!options || !options.secret) {
-    throw new Error('secret option required')
+  const state = {
+    hooks: {}
   }
 
-  const state = {
-    hooks: {},
-    secret: options.secret
+  if (options && options.transform) {
+    state.transform = options.transform
   }
 
   return {
-    sign: sign.bind(null, state.secret),
-    verify: verify.bind(null, state.secret),
     on: on.bind(null, state),
     removeListener: removeListener.bind(null, state),
     receive: receive.bind(null, state)

--- a/event-handler/receive.js
+++ b/event-handler/receive.js
@@ -6,11 +6,7 @@ const wrapErrorHandler = require('./wrap-error-handler')
 
 // main handler function
 function receiverHandle (state, event) {
-  if (!event || !event.id) {
-    throw new Error('Event id not passed')
-  }
-
-  if (!event.name) {
+  if (!event || !event.name) {
     throw new Error('Event name not passed')
   }
 

--- a/index.js
+++ b/index.js
@@ -2,22 +2,25 @@ module.exports = createWebhooksApi
 
 const createEventHandler = require('./event-handler')
 const middleware = require('./middleware/middleware')
+const sign = require('./sign')
+const verify = require('./verify')
 
 function createWebhooksApi (options) {
-  if (!options) {
-    options = {}
+  if (!options || !options.secret) {
+    throw new Error('options.secret required')
   }
 
   const state = {
     eventHandler: createEventHandler(options),
-    path: options.path || '/'
+    path: options.path || '/',
+    secret: options.secret
   }
 
   const webhooksMiddleware = middleware.bind(null, state)
 
   return {
-    sign: state.eventHandler.sign,
-    verify: state.eventHandler.verify,
+    sign: sign.bind(null, options.secret),
+    verify: verify.bind(null, options.secret),
     on: state.eventHandler.on,
     removeListener: state.eventHandler.removeListener,
     receive: state.eventHandler.receive,

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -6,13 +6,14 @@ const createEventHandler = require('../event-handler')
 const middleware = require('./middleware')
 
 function createMiddleware (options) {
-  if (!options) {
-    options = {}
+  if (!options || !options.secret) {
+    throw new Error('options.secret required')
   }
 
   const state = {
     eventHandler: createEventHandler(options),
-    path: options.path || '/'
+    path: options.path || '/',
+    secret: options.secret
   }
 
   const api = middleware.bind(null, state)

--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -2,6 +2,7 @@ module.exports = middleware
 
 const isntWebhook = require('./isnt-webhook')
 const getMissingHeaders = require('./get-missing-headers')
+const verify = require('../verify')
 
 const debug = require('debug')('webhooks:receiver')
 function middleware (state, request, response, next) {
@@ -48,8 +49,8 @@ function middleware (state, request, response, next) {
 
   request.on('end', () => {
     const payload = Buffer.concat(dataChunks).toString()
-
-    const matchesSignature = state.eventHandler.verify(
+    const matchesSignature = verify(
+      state.secret,
       payload,
       signature
     )
@@ -63,7 +64,7 @@ function middleware (state, request, response, next) {
     state.eventHandler.receive({
       id: id,
       name: eventName,
-      data: JSON.parse(payload),
+      payload: JSON.parse(payload),
       signature
     })
 

--- a/sign/README.md
+++ b/sign/README.md
@@ -4,7 +4,7 @@ The `sign` method can be used as a standalone method.
 
 ```js
 const sign = require('@octokit/webhooks/sign')
-const signature = sign(secret, eventData)
+const signature = sign(secret, eventPayload)
 // string like "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8"
 ```
 
@@ -24,7 +24,7 @@ const signature = sign(secret, eventData)
   <tr>
     <td>
       <code>
-        data
+        eventPayload
       </code>
       <em>
         (Object)
@@ -32,7 +32,7 @@ const signature = sign(secret, eventData)
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook request body as received from GitHub
+      Webhook request payload as received from GitHub
     </td>
   </tr>
 </table>

--- a/sign/index.js
+++ b/sign/index.js
@@ -2,11 +2,11 @@ module.exports = sign
 
 const crypto = require('crypto')
 
-function sign (secret, data) {
-  if (!secret || !data) {
-    throw new TypeError('secret & data required')
+function sign (secret, payload) {
+  if (!secret || !payload) {
+    throw new TypeError('secret & payload required')
   }
 
-  data = typeof data === 'string' ? data : JSON.stringify(data)
-  return 'sha1=' + crypto.createHmac('sha1', secret).update(data).digest('hex')
+  payload = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  return 'sha1=' + crypto.createHmac('sha1', secret).update(payload).digest('hex')
 }

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -55,8 +55,14 @@ test('GET /', (t) => {
 })
 
 test('POST / with push event payload', {only: true}, (t) => {
+  t.plan(2)
+
   const api = new Webhooks({secret: 'mysecret'})
   const server = http.createServer(api.middleware)
+
+  api.on('push', (event) => {
+    t.is(event.id, '123e4567-e89b-12d3-a456-426655440000')
+  })
 
   promisify(server.listen.bind(server))(this.port)
 
@@ -77,37 +83,7 @@ test('POST / with push event payload', {only: true}, (t) => {
   })
 
   .then(() => {
-    server.close(t.end)
-  })
-
-  .catch(t.error)
-})
-
-test('POST / with push event payload (without signature)', (t) => {
-  const api = new Webhooks({secret: 'mysecret'})
-  const server = http.createServer(api.middleware)
-
-  promisify(server.listen.bind(server))(this.port)
-
-  .then(() => {
-    return axios.post(`http://localhost:${this.port}`, pushEventPayload, {
-      headers: {
-        'X-GitHub-Delivery': '123e4567-e89b-12d3-a456-426655440000',
-        'X-GitHub-Event': 'push'
-      }
-    })
-  })
-
-  .then(() => {
-    t.fail('should return a 400')
-  })
-
-  .catch(error => {
-    t.is(error.response.status, 400)
-  })
-
-  .then(() => {
-    server.close(t.end)
+    server.close()
   })
 
   .catch(t.error)

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -54,7 +54,7 @@ test('GET /', (t) => {
   .catch(t.error)
 })
 
-test('POST / with push event payload', (t) => {
+test('POST / with push event payload', {only: true}, (t) => {
   const api = new Webhooks({secret: 'mysecret'})
   const server = http.createServer(api.middleware)
 

--- a/test/integration/sign-test.js
+++ b/test/integration/sign-test.js
@@ -2,7 +2,7 @@ const test = require('tap').test
 
 const sign = require('../../sign')
 
-const data = {
+const eventPayload = {
   foo: 'bar'
 }
 const secret = 'mysecret'
@@ -12,25 +12,25 @@ test('sign() without options throws', (t) => {
   t.end()
 })
 
-test('sign(data) without options.secret throws', (t) => {
-  t.throws(sign.bind(null, undefined, data))
+test('sign(undefined, eventPayload) without secret throws', (t) => {
+  t.throws(sign.bind(null, undefined, eventPayload))
   t.end()
 })
 
-test('sign(secret) without options.data throws', (t) => {
+test('sign(secret) without eventPayload throws', (t) => {
   t.throws(sign.bind(null, secret))
   t.end()
 })
 
-test('sign(data, secret) with data as object returns expected signature', (t) => {
-  const signature = sign(secret, data)
+test('sign(secret, eventPayload) with eventPayload as object returns expected signature', (t) => {
+  const signature = sign(secret, eventPayload)
   t.is(signature, 'sha1=d03207e4b030cf234e3447bac4d93add4c6643d8')
 
   t.end()
 })
 
-test('sign(data, secret) with data as string returns expected signature', (t) => {
-  const signature = sign(secret, JSON.stringify(data))
+test('sign(secret, eventPayload) with eventPayload as string returns expected signature', (t) => {
+  const signature = sign(secret, JSON.stringify(eventPayload))
   t.is(signature, 'sha1=d03207e4b030cf234e3447bac4d93add4c6643d8')
 
   t.end()

--- a/test/integration/verify-test.js
+++ b/test/integration/verify-test.js
@@ -2,7 +2,7 @@ const test = require('tap').test
 
 const verify = require('../../verify')
 
-const data = {
+const eventPayload = {
   foo: 'bar'
 }
 const secret = 'mysecret'
@@ -13,37 +13,37 @@ test('verify() without options throws', (t) => {
   t.end()
 })
 
-test('verify(data) without options.secret throws', (t) => {
-  t.throws(verify.bind(null, undefined, data))
+test('verify(undefined, eventPayload) without secret throws', (t) => {
+  t.throws(verify.bind(null, undefined, eventPayload))
   t.end()
 })
 
-test('verify(secret) without options.data throws', (t) => {
+test('verify(secret) without eventPayload throws', (t) => {
   t.throws(verify.bind(null, secret))
   t.end()
 })
 
-test('verify(data, secret) without options.signature throws', (t) => {
-  t.throws(verify.bind(null, secret, data))
+test('verify(secret, eventPayload) without options.signature throws', (t) => {
+  t.throws(verify.bind(null, secret, eventPayload))
   t.end()
 })
 
-test('verify(data, secret, signature) returns true for correct signature', (t) => {
-  const signatureMatches = verify(secret, data, signature)
+test('verify(secret, eventPayload, signature) returns true for correct signature', (t) => {
+  const signatureMatches = verify(secret, eventPayload, signature)
   t.is(signatureMatches, true)
 
   t.end()
 })
 
-test('verify(data, secret, signature) returns false for incorrect signature', (t) => {
-  const signatureMatches = verify(secret, data, 'foo')
+test('verify(secret, eventPayload, signature) returns false for incorrect signature', (t) => {
+  const signatureMatches = verify(secret, eventPayload, 'foo')
   t.is(signatureMatches, false)
 
   t.end()
 })
 
-test('verify(data, secret, signature) returns false for correct secret', (t) => {
-  const signatureMatches = verify('foo', data, signature)
+test('verify(secret, eventPayload, signature) returns false for correct secret', (t) => {
+  const signatureMatches = verify('foo', eventPayload, signature)
   t.is(signatureMatches, false)
 
   t.end()

--- a/test/unit/event-handler-receive-test.js
+++ b/test/unit/event-handler-receive-test.js
@@ -14,16 +14,16 @@ test('options: none', t => {
   t.end()
 })
 
-test('options: id', t => {
+test('options: name', t => {
   t.throws(() => {
-    receive(state, {id: '123'})
+    receive(state, {name: 'foo'})
   })
   t.end()
 })
 
-test('options: id, name', t => {
-  t.throws(() => {
-    receive(state, {id: '123', name: 'foo'})
+test('options: name, payload', t => {
+  t.doesNotThrow(() => {
+    receive(state, {name: 'foo', payload: {}})
   })
   t.end()
 })

--- a/verify/README.md
+++ b/verify/README.md
@@ -24,7 +24,7 @@ const matchesSignature = verify(secret, eventData, signature)
   <tr>
     <td>
       <code>
-        data
+        eventPayload
       </code>
       <em>
         (Object)
@@ -32,7 +32,7 @@ const matchesSignature = verify(secret, eventData, signature)
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook request body as received from GitHub
+      Webhook request payload as received from GitHub
     </td>
   </tr>
   <tr>
@@ -51,6 +51,6 @@ const matchesSignature = verify(secret, eventData, signature)
   </tr>
 </table>
 
-Returns `true` or `false`. Throws error if `secret, ``data` or `signature` not passed.
+Returns `true` or `false`. Throws error if `secret, ``eventPayload` or `signature` not passed.
 
 Back to [@octokit/webhooks README](..).

--- a/verify/index.js
+++ b/verify/index.js
@@ -4,13 +4,13 @@ const Buffer = require('buffer').Buffer
 
 const sign = require('../sign')
 
-function verify (secret, data, signature) {
-  if (!secret || !data || !signature) {
-    throw new TypeError('secret, data & signature required')
+function verify (secret, eventPayload, signature) {
+  if (!secret || !eventPayload || !signature) {
+    throw new TypeError('secret, eventPayload & signature required')
   }
 
   return Buffer.compare(
     Buffer.from(signature),
-    Buffer.from(sign(secret, data))
+    Buffer.from(sign(secret, eventPayload))
   ) === 0
 }


### PR DESCRIPTION
```js
const EventHandler = require(@octokit/webhooks/event-handler)
const eventHandler = new EventHandler({
  async transform (event) {
    // optionally transform passed event before handlers are called
    return event
  }
})
```

### BREAKING CHANGE:

`event.data` is now `event.payload`

### BREAKING CHANGE:

event handlers are now called with single `{id, name, payload}` object

Before

```
webhooks.on(push, (data, {id, name}) => {})
```

Now

```js
webhooks.on(push, ({id, name, payload}) => {})
```