### PR TITLE
don’t pass signature to `eventHandler.receive` in middleware

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -64,8 +64,7 @@ function middleware (state, request, response, next) {
     state.eventHandler.receive({
       id: id,
       name: eventName,
-      payload: JSON.parse(payload),
-      signature
+      payload: JSON.parse(payload)
     })
 
     .then(() => {


### PR DESCRIPTION
verification has to be done manually beforehand