### PR TITLE
webhooks.verifyAndReceive()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ require('http').createServer(webhooks.middleware).listen(3000)
 1. [Constructor](#constructor)
 2. [webhooks.sign()](#webhookssign)
 3. [webhooks.verify()](#webhooksverify)
+4. [webhooks.verifyAndReceive()](#webhooksverifyandreceive)
 4. [webhooks.receive()](#webhooksreceive)
 5. [webhooks.on()](#webhookson)
 6. [webhooks.removeListener()](#webhooksremoveListener)
@@ -161,6 +162,95 @@ weebhooks.verify(eventPayload, signature)
 Returns `true` or `false`. Throws error if `eventPayload` or `signature` not passed.
 
 Can also be used [standalone](verify/).
+
+### webhooks.verifyAndReceive()
+
+```js
+weebhooks.verifyAndReceive({id, name, payload, signature})
+```
+
+<table width="100%">
+  <tr>
+    <td>
+      <code>
+        id
+      </code>
+      <em>
+        String
+      </em>
+    </td>
+    <td>
+      Unique webhook event request id
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        name
+      </code>
+      <em>
+        String
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong>
+      Name of the event. (Event names are set as <a href="https://developer.github.com/webhooks/#delivery-headers"><code>X-GitHub-Event</code> header</a>
+      in the webhook event request.)
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        payload
+      </code>
+      <em>
+        Object
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong>
+      Webhook event request payload as received from GitHub.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        signature
+      </code>
+      <em>
+        (String)
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong>
+      Signature string as calculated by <code><a href="#webhookssign">webhooks.sign()</a></code>.
+    </td>
+  </tr>
+</table>
+
+Returns a promise.
+
+Verifies event using [webhooks.verify()](#webhooksverify), then handles the event using [webhooks.receive()](#webhooksreceive).
+
+Additionally, if verification fails, rejects return promise and emits an `error` event.
+
+Example
+
+```js
+const WebhooksApi = require('@octokit/webhooks')
+const webhooks = new WebhooksApi({
+  secret: 'mysecret'
+})
+eventHandler.on('error', handleSignatureVerificationError)
+
+// put this inside your webhooks route handler
+eventHandler.verifyAndReceive({
+  id: request.headers['x-github-delivery'],
+  name: request.headers['x-github-event'],
+  payload: request.body,
+  signature: request.headers['x-github-signature']
+}).catch(handleErrorsFromHooks)
+```
 
 ### webhooks.receive()
 

--- a/event-handler/receive.js
+++ b/event-handler/receive.js
@@ -6,6 +6,14 @@ const wrapErrorHandler = require('./wrap-error-handler')
 
 // main handler function
 function receiverHandle (state, event) {
+  const errorHandlers = state.hooks.error || []
+
+  if (event instanceof Error) {
+    errorHandlers.forEach(handler => wrapErrorHandler(handler, event))
+
+    return Promise.reject(event)
+  }
+
   if (!event || !event.name) {
     throw new Error('Event name not passed')
   }
@@ -45,10 +53,7 @@ function receiverHandle (state, event) {
       return
     }
 
-    const errorHandlers = state.hooks.error
-    if (errorHandlers) {
-      errorHandlers.forEach(handler => errors.forEach(wrapErrorHandler.bind(null, handler)))
-    }
+    errorHandlers.forEach(handler => errors.forEach(wrapErrorHandler.bind(null, handler)))
 
     const error = new Error('Webhook handler error')
     error.errors = errors

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const createEventHandler = require('./event-handler')
 const middleware = require('./middleware/middleware')
 const sign = require('./sign')
 const verify = require('./verify')
+const verifyAndReceive = require('./middleware/verify-and-receive')
 
 function createWebhooksApi (options) {
   if (!options || !options.secret) {
@@ -16,14 +17,13 @@ function createWebhooksApi (options) {
     secret: options.secret
   }
 
-  const webhooksMiddleware = middleware.bind(null, state)
-
   return {
     sign: sign.bind(null, options.secret),
     verify: verify.bind(null, options.secret),
     on: state.eventHandler.on,
     removeListener: state.eventHandler.removeListener,
     receive: state.eventHandler.receive,
-    middleware: webhooksMiddleware
+    middleware: middleware.bind(null, state),
+    verifyAndReceive: verifyAndReceive.bind(null, state)
   }
 }

--- a/middleware/verify-and-receive.js
+++ b/middleware/verify-and-receive.js
@@ -1,0 +1,22 @@
+module.exports = verifyAndReceive
+
+const verify = require('../verify')
+
+function verifyAndReceive (state, event) {
+  const matchesSignature = verify(state.secret, event.payload, event.signature)
+
+  if (!matchesSignature) {
+    const error = new Error('signature does not match event payload and secret')
+
+    error.event = event
+    error.status = 400
+
+    return state.eventHandler.receive(error)
+  }
+
+  return state.eventHandler.receive({
+    id: event.id,
+    name: event.name,
+    payload: event.payload
+  })
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug": "^3.1.0",
     "get-port": "^3.2.0",
     "pify": "^3.0.0",
+    "proxyquire": "^1.8.0",
     "semantic-release": "^11.0.2",
     "simple-mock": "^0.8.0",
     "standard": "^10.0.3",

--- a/test/integration/middleware-test.js
+++ b/test/integration/middleware-test.js
@@ -18,7 +18,7 @@ test('request error', t => {
   requestMock.url = '/'
 
   const responseMock = {
-    end: simple.stub()
+    end: simple.spy()
   }
 
   const middleware = createMiddleware({secret: 'mysecret'})

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -3,6 +3,7 @@ const http = require('http')
 const axios = require('axios')
 const getPort = require('get-port')
 const promisify = require('pify')
+const simple = require('simple-mock')
 const Tap = require('tap')
 
 const Webhooks = require('../../')
@@ -54,7 +55,7 @@ test('GET /', (t) => {
   .catch(t.error)
 })
 
-test('POST / with push event payload', {only: true}, (t) => {
+test('POST / with push event payload', (t) => {
   t.plan(2)
 
   const api = new Webhooks({secret: 'mysecret'})
@@ -122,6 +123,8 @@ test('POST / with push event payload (no signature)', (t) => {
 test('POST / with push event payload (invalid signature)', (t) => {
   const api = new Webhooks({secret: 'mysecret'})
   const server = http.createServer(api.middleware)
+  const errorHandler = simple.spy()
+  api.on('error', errorHandler)
 
   promisify(server.listen.bind(server))(this.port)
 
@@ -144,6 +147,7 @@ test('POST / with push event payload (invalid signature)', (t) => {
   })
 
   .then(() => {
+    t.is(errorHandler.callCount, 1, 'calls "error" event handler')
     server.close(t.end)
   })
 

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -10,6 +10,7 @@ test('@octokit/webhooks', (t) => {
   t.type(api.removeListener, 'function')
   t.type(api.receive, 'function')
   t.type(api.middleware, 'function')
+  t.type(api.verifyAndReceive, 'function')
 
   t.end()
 })


### PR DESCRIPTION
```js
weebhooks.verifyAndReceive({id, name, payload, signature})
```

<table width="100%">
  <tr>
    <td>
      <code>
        id
      </code>
      <em>
        String
      </em>
    </td>
    <td>
      Unique webhook event request id
    </td>
  </tr>
  <tr>
    <td>
      <code>
        name
      </code>
      <em>
        String
      </em>
    </td>
    <td>
      <strong>Required.</strong>
      Name of the event. (Event names are set as <a href="https://developer.github.com/webhooks/#delivery-headers"><code>X-GitHub-Event</code> header</a>
      in the webhook event request.)
    </td>
  </tr>
  <tr>
    <td>
      <code>
        payload
      </code>
      <em>
        Object
      </em>
    </td>
    <td>
      <strong>Required.</strong>
      Webhook event request payload as received from GitHub.
    </td>
  </tr>
  <tr>
    <td>
      <code>
        signature
      </code>
      <em>
        (String)
      </em>
    </td>
    <td>
      <strong>Required.</strong>
      Signature string as calculated by <code><a href="#webhookssign">webhooks.sign()</a></code>.
    </td>
  </tr>
</table>

Returns a promise.

Verifies event using [webhooks.verify()](#webhooksverify), then handles the event using [webhooks.receive()](#webhooksreceive).

Additionally, if verification fails, rejects return promise and emits an `error` event.

Example

```js
const WebhooksApi = require('@octokit/webhooks')
const webhooks = new WebhooksApi({
  secret: 'mysecret'
})
eventHandler.on('error', handleSignatureVerificationError)

// put this inside your webhooks route handler
eventHandler.verifyAndReceive({
  id: request.headers['x-github-delivery'],
  name: request.headers['x-github-event'],
  payload: request.body,
  signature: request.headers['x-github-signature']
}).catch(handleErrorsFromHooks)
```
