### PR TITLE
Unknown events: log warning instead of throwing error

### DIFF
--- a/event-handler/on.js
+++ b/event-handler/on.js
@@ -9,7 +9,7 @@ function receiverOn (state, webhookNameOrNames, handler) {
   }
 
   if (webhookNames.indexOf(webhookNameOrNames) === -1) {
-    throw new Error(`${webhookNameOrNames} is not a valid webhook name`)
+    console.warn(`"${webhookNameOrNames}" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)`)
   }
 
   if (!state.hooks[webhookNameOrNames]) {

--- a/test/unit/event-handler-on-test.js
+++ b/test/unit/event-handler-on-test.js
@@ -1,3 +1,4 @@
+const simple = require('simple-mock')
 const test = require('tap').test
 
 const receiverOn = require('../../event-handler/on')
@@ -9,8 +10,11 @@ const state = {
 }
 
 test('receiver.on with invalid event name', t => {
-  t.throws(() => {
-    receiverOn(state, 'foo', noop)
-  })
+  simple.mock(console, 'warn').callFn(function () {})
+  receiverOn(state, 'foo', noop)
+  t.equals(console.warn.callCount, 1)
+  t.equals(console.warn.lastCall.arg, '"foo" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)')
+
+  simple.restore()
   t.end()
 })


### PR DESCRIPTION
### Breaking change

Before, this code would throw an error

```js
webhooks.on('woodstock', handler)
```

Now it logs a warning: `"woodstock" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)`

---

closes #20 