### PR TITLE
handling request.body

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -6,7 +6,7 @@ const verifyAndReceive = require('./verify-and-receive')
 
 const debug = require('debug')('webhooks:receiver')
 function middleware (state, request, response, next) {
-  function handlePayload(payload) {
+  function handlePayload (payload) {
     verifyAndReceive(state, {
       id: id,
       name: eventName,
@@ -63,14 +63,14 @@ function middleware (state, request, response, next) {
       response.statusCode = 500
       response.end(error.toString())
     })
-  
+
     request.on('data', (chunk) => {
       dataChunks.push(chunk)
     })
-  
+
     request.on('end', () => {
       const payload = Buffer.concat(dataChunks).toString()
       handlePayload(JSON.parse(payload))
-    }) 
+    })
   }
 }

--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -55,6 +55,7 @@ function middleware (state, request, response, next) {
 
   debug(`${eventName} event received (id: ${id})`)
 
+  // this check is necessary when request.body already exists, since the data event will not fire
   if (request.body) {
     handlePayload(request.body)
   } else {

--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -6,6 +6,24 @@ const verifyAndReceive = require('./verify-and-receive')
 
 const debug = require('debug')('webhooks:receiver')
 function middleware (state, request, response, next) {
+  function handlePayload(payload) {
+    verifyAndReceive(state, {
+      id: id,
+      name: eventName,
+      payload,
+      signature
+    })
+
+      .then(() => {
+        response.end('ok\n')
+      })
+
+      .catch(error => {
+        response.statusCode = error.status || 500
+        response.end(error.toString())
+      })
+  }
+
   if (isntWebhook(request, {path: state.path})) {
     // the next callback is set when used as an express middleware. That allows
     // it to define custom routes like /my/custom/page while the webhooks are
@@ -37,33 +55,22 @@ function middleware (state, request, response, next) {
 
   debug(`${eventName} event received (id: ${id})`)
 
-  const dataChunks = []
-  request.on('error', (error) => {
-    response.statusCode = 500
-    response.end(error.toString())
-  })
-
-  request.on('data', (chunk) => {
-    dataChunks.push(chunk)
-  })
-
-  request.on('end', () => {
-    const payload = Buffer.concat(dataChunks).toString()
-
-    verifyAndReceive(state, {
-      id: id,
-      name: eventName,
-      payload: JSON.parse(payload),
-      signature
+  if (request.body) {
+    handlePayload(request.body)
+  } else {
+    const dataChunks = []
+    request.on('error', (error) => {
+      response.statusCode = 500
+      response.end(error.toString())
     })
-
-      .then(() => {
-        response.end('ok\n')
-      })
-
-      .catch(error => {
-        response.statusCode = error.status || 500
-        response.end(error.toString())
-      })
-  })
+  
+    request.on('data', (chunk) => {
+      dataChunks.push(chunk)
+    })
+  
+    request.on('end', () => {
+      const payload = Buffer.concat(dataChunks).toString()
+      handlePayload(JSON.parse(payload))
+    }) 
+  }
 }


### PR DESCRIPTION
This handles the case where request.body already exists. I was running into trouble using this package on Firebase, as it parses the body automatically, causing request.on('data') not to fire. 