### PR TITLE
Trigger error handler when missing headers

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -24,11 +24,13 @@ function middleware (state, request, response, next) {
 
   const missingHeaders = getMissingHeaders(request).join(', ')
   if (missingHeaders) {
-    debug(`ignored: ${request.method} ${request.url} due to missing headers: ${missingHeaders}`)
+    const error = new Error(`Required headers missing: ${missingHeaders}`)
 
-    response.statusCode = 400
-    response.end(`Required headers missing: ${missingHeaders}`)
-    return
+    return state.eventHandler.receive(error)
+      .catch(() => {
+        response.statusCode = 400
+        response.end(error.message)
+      })
   }
 
   const eventName = request.headers['x-github-event']

--- a/test/integration/server-test.js
+++ b/test/integration/server-test.js
@@ -93,6 +93,8 @@ test('POST / with push event payload', (t) => {
 test('POST / with push event payload (no signature)', (t) => {
   const api = new Webhooks({secret: 'mysecret'})
   const server = http.createServer(api.middleware)
+  const errorHandler = simple.spy()
+  api.on('error', errorHandler)
 
   promisify(server.listen.bind(server))(this.port)
 
@@ -114,6 +116,7 @@ test('POST / with push event payload (no signature)', (t) => {
     })
 
     .then(() => {
+      t.is(errorHandler.callCount, 1, 'calls "error" event handler')
       server.close(t.end)
     })
 


### PR DESCRIPTION
This fixes #29 by triggering an error when headers are missing. 

cc @hiimbex @mwebler
