### PR TITLE
Fix header name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ eventHandler.verifyAndReceive({
   id: request.headers['x-github-delivery'],
   name: request.headers['x-github-event'],
   payload: request.body,
-  signature: request.headers['x-github-signature']
+  signature: request.headers['x-hub-signature']
 }).catch(handleErrorsFromHooks)
 ```
 


### PR DESCRIPTION
Maybe its because im using GitHub Apps but this header name is wrong

-----
[View rendered README.md](https://github.com/nbransby/webhooks.js/blob/master/README.md)