### PR TITLE
Typescript: export Webhooks explicitly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3476,374 +3476,367 @@ export namespace Webhooks {
     host?: string;
     url?: string;
   }
-  export class Webhooks {
-    constructor(options: Options);
-
-    public on(event: "error", callback: (event: Error) => void): void;
-    public on(
-      event: "*" | string | string[],
-      callback: (event: Webhooks.WebhookEvent<any>) => void
-    ): void;
-    public on(
-      event: "*" | string | string[],
-      callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>
-    ): void;
-
-    public on(
-      event:
-        | "check_run"
-        | "check_run.completed"
-        | "check_run.created"
-        | "check_run.requested_action"
-        | "check_run.rerequested",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadCheckRun>) => void
-    ): void;
-
-    public on(
-      event:
-        | "check_suite"
-        | "check_suite.completed"
-        | "check_suite.requested"
-        | "check_suite.rerequested",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadCheckSuite>) => void
-    ): void;
-
-    public on(
-      event: "commit_comment" | "commit_comment.created",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadCommitComment>
-      ) => void
-    ): void;
-
-    public on(
-      event: "create",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadCreate>) => void
-    ): void;
-
-    public on(
-      event: "delete",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadDelete>) => void
-    ): void;
-
-    public on(
-      event: "deployment",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadDeployment>) => void
-    ): void;
-
-    public on(
-      event: "deployment_status",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadDeploymentStatus>
-      ) => void
-    ): void;
-
-    public on(
-      event: "fork",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadFork>) => void
-    ): void;
-
-    public on(
-      event: "github_app_authorization",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadGithubAppAuthorization>
-      ) => void
-    ): void;
-
-    public on(
-      event: "gollum",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadGollum>) => void
-    ): void;
-
-    public on(
-      event: "installation" | "installation.created" | "installation.deleted",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadInstallation>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "installation_repositories"
-        | "installation_repositories.added"
-        | "installation_repositories.removed",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadInstallationRepositories>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "issue_comment"
-        | "issue_comment.created"
-        | "issue_comment.deleted"
-        | "issue_comment.edited",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadIssueComment>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "issues"
-        | "issues.assigned"
-        | "issues.closed"
-        | "issues.deleted"
-        | "issues.demilestoned"
-        | "issues.edited"
-        | "issues.labeled"
-        | "issues.milestoned"
-        | "issues.opened"
-        | "issues.reopened"
-        | "issues.transferred"
-        | "issues.unassigned"
-        | "issues.unlabeled",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadIssues>) => void
-    ): void;
-
-    public on(
-      event: "label" | "label.created" | "label.deleted" | "label.edited",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadLabel>) => void
-    ): void;
-
-    public on(
-      event:
-        | "marketplace_purchase"
-        | "marketplace_purchase.cancelled"
-        | "marketplace_purchase.changed"
-        | "marketplace_purchase.pending_change"
-        | "marketplace_purchase.pending_change_cancelled"
-        | "marketplace_purchase.purchased",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadMarketplacePurchase>
-      ) => void
-    ): void;
-
-    public on(
-      event: "member" | "member.added" | "member.deleted" | "member.edited",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadMember>) => void
-    ): void;
-
-    public on(
-      event: "membership" | "membership.added" | "membership.removed",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadMembership>) => void
-    ): void;
-
-    public on(
-      event:
-        | "milestone"
-        | "milestone.closed"
-        | "milestone.created"
-        | "milestone.deleted"
-        | "milestone.edited"
-        | "milestone.opened",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadMilestone>) => void
-    ): void;
-
-    public on(
-      event:
-        | "organization"
-        | "organization.member_added"
-        | "organization.member_invited"
-        | "organization.member_removed",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadOrganization>
-      ) => void
-    ): void;
-
-    public on(
-      event: "org_block" | "org_block.blocked" | "org_block.unblocked",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadOrgBlock>) => void
-    ): void;
-
-    public on(
-      event: "page_build",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadPageBuild>) => void
-    ): void;
-
-    public on(
-      event:
-        | "project_card"
-        | "project_card.converted"
-        | "project_card.created"
-        | "project_card.deleted"
-        | "project_card.edited"
-        | "project_card.moved",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadProjectCard>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "project_column"
-        | "project_column.created"
-        | "project_column.deleted"
-        | "project_column.edited"
-        | "project_column.moved",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadProjectColumn>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "project"
-        | "project.closed"
-        | "project.created"
-        | "project.deleted"
-        | "project.edited"
-        | "project.reopened",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadProject>) => void
-    ): void;
-
-    public on(
-      event: "public",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadPublic>) => void
-    ): void;
-
-    public on(
-      event:
-        | "pull_request"
-        | "pull_request.assigned"
-        | "pull_request.closed"
-        | "pull_request.edited"
-        | "pull_request.labeled"
-        | "pull_request.opened"
-        | "pull_request.reopened"
-        | "pull_request.review_request_removed"
-        | "pull_request.review_requested"
-        | "pull_request.unassigned"
-        | "pull_request.unlabeled"
-        | "pull_request.synchronize",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadPullRequest>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "pull_request_review"
-        | "pull_request_review.dismissed"
-        | "pull_request_review.edited"
-        | "pull_request_review.submitted",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadPullRequestReview>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "pull_request_review_comment"
-        | "pull_request_review_comment.created"
-        | "pull_request_review_comment.deleted"
-        | "pull_request_review_comment.edited",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadPullRequestReviewComment>
-      ) => void
-    ): void;
-
-    public on(
-      event: "push",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadPush>) => void
-    ): void;
-
-    public on(
-      event: "release" | "release.published",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadRelease>) => void
-    ): void;
-
-    public on(
-      event:
-        | "repository"
-        | "repository.archived"
-        | "repository.created"
-        | "repository.deleted"
-        | "repository.privatized"
-        | "repository.publicized"
-        | "repository.unarchived",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadRepository>) => void
-    ): void;
-
-    public on(
-      event: "repository_import",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadRepositoryImport>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "repository_vulnerability_alert"
-        | "repository_vulnerability_alert.create"
-        | "repository_vulnerability_alert.dismiss"
-        | "repository_vulnerability_alert.resolve",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadRepositoryVulnerabilityAlert>
-      ) => void
-    ): void;
-
-    public on(
-      event:
-        | "security_advisory"
-        | "security_advisory.performed"
-        | "security_advisory.published"
-        | "security_advisory.updated",
-      callback: (
-        event: Webhooks.WebhookEvent<WebhookPayloadSecurityAdvisory>
-      ) => void
-    ): void;
-
-    public on(
-      event: "status",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadStatus>) => void
-    ): void;
-
-    public on(
-      event:
-        | "team"
-        | "team.added_to_repository"
-        | "team.created"
-        | "team.deleted"
-        | "team.edited"
-        | "team.removed_from_repository",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadTeam>) => void
-    ): void;
-
-    public on(
-      event: "team_add",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadTeamAdd>) => void
-    ): void;
-
-    public on(
-      event: "watch" | "watch.started",
-      callback: (event: Webhooks.WebhookEvent<WebhookPayloadWatch>) => void
-    ): void;
-
-    public sign(data: any): string;
-    public verify(eventPayload: any, signature: string): boolean;
-    public verifyAndReceive(options: {
-      id: string;
-      name: string;
-      payload: any;
-      signature: string;
-    }): Promise<void>;
-    public receive(options: {
-      id: string;
-      name: string;
-      payload: any;
-    }): Promise<void>;
-    public removeListener(
-      event: string | string[],
-      callback: (event: Webhooks.WebhookEvent<any>) => void
-    ): void;
-    public removeListener(
-      event: string | string[],
-      callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>
-    ): void;
-    public middleware(
-      request: http.ClientRequest,
-      response: http.ServerResponse,
-      next: (err?: any) => void
-    ): (request: http.IncomingMessage, response: http.ServerResponse) => void;
-  }
 }
+
+export class Webhooks {
+  constructor(options: Options);
+
+  public on(event: "error", callback: (event: Error) => void): void;
+  public on(
+    event: "*" | string | string[],
+    callback: (event: Webhooks.WebhookEvent<any>) => void
+  ): void;
+  public on(
+    event: "*" | string | string[],
+    callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>
+  ): void;
+
+  public on(
+    event:
+      | "check_run"
+      | "check_run.completed"
+      | "check_run.created"
+      | "check_run.requested_action"
+      | "check_run.rerequested",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadCheckRun>) => void
+  ): void;
+
+  public on(
+    event:
+      | "check_suite"
+      | "check_suite.completed"
+      | "check_suite.requested"
+      | "check_suite.rerequested",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadCheckSuite>) => void
+  ): void;
+
+  public on(
+    event: "commit_comment" | "commit_comment.created",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadCommitComment>
+    ) => void
+  ): void;
+
+  public on(
+    event: "create",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadCreate>) => void
+  ): void;
+
+  public on(
+    event: "delete",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadDelete>) => void
+  ): void;
+
+  public on(
+    event: "deployment",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadDeployment>) => void
+  ): void;
+
+  public on(
+    event: "deployment_status",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadDeploymentStatus>
+    ) => void
+  ): void;
+
+  public on(
+    event: "fork",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadFork>) => void
+  ): void;
+
+  public on(
+    event: "github_app_authorization",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadGithubAppAuthorization>
+    ) => void
+  ): void;
+
+  public on(
+    event: "gollum",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadGollum>) => void
+  ): void;
+
+  public on(
+    event: "installation" | "installation.created" | "installation.deleted",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadInstallation>) => void
+  ): void;
+
+  public on(
+    event:
+      | "installation_repositories"
+      | "installation_repositories.added"
+      | "installation_repositories.removed",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadInstallationRepositories>
+    ) => void
+  ): void;
+
+  public on(
+    event:
+      | "issue_comment"
+      | "issue_comment.created"
+      | "issue_comment.deleted"
+      | "issue_comment.edited",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadIssueComment>) => void
+  ): void;
+
+  public on(
+    event:
+      | "issues"
+      | "issues.assigned"
+      | "issues.closed"
+      | "issues.deleted"
+      | "issues.demilestoned"
+      | "issues.edited"
+      | "issues.labeled"
+      | "issues.milestoned"
+      | "issues.opened"
+      | "issues.reopened"
+      | "issues.transferred"
+      | "issues.unassigned"
+      | "issues.unlabeled",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadIssues>) => void
+  ): void;
+
+  public on(
+    event: "label" | "label.created" | "label.deleted" | "label.edited",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadLabel>) => void
+  ): void;
+
+  public on(
+    event:
+      | "marketplace_purchase"
+      | "marketplace_purchase.cancelled"
+      | "marketplace_purchase.changed"
+      | "marketplace_purchase.pending_change"
+      | "marketplace_purchase.pending_change_cancelled"
+      | "marketplace_purchase.purchased",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadMarketplacePurchase>
+    ) => void
+  ): void;
+
+  public on(
+    event: "member" | "member.added" | "member.deleted" | "member.edited",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadMember>) => void
+  ): void;
+
+  public on(
+    event: "membership" | "membership.added" | "membership.removed",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadMembership>) => void
+  ): void;
+
+  public on(
+    event:
+      | "milestone"
+      | "milestone.closed"
+      | "milestone.created"
+      | "milestone.deleted"
+      | "milestone.edited"
+      | "milestone.opened",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadMilestone>) => void
+  ): void;
+
+  public on(
+    event:
+      | "organization"
+      | "organization.member_added"
+      | "organization.member_invited"
+      | "organization.member_removed",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadOrganization>) => void
+  ): void;
+
+  public on(
+    event: "org_block" | "org_block.blocked" | "org_block.unblocked",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadOrgBlock>) => void
+  ): void;
+
+  public on(
+    event: "page_build",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadPageBuild>) => void
+  ): void;
+
+  public on(
+    event:
+      | "project_card"
+      | "project_card.converted"
+      | "project_card.created"
+      | "project_card.deleted"
+      | "project_card.edited"
+      | "project_card.moved",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadProjectCard>) => void
+  ): void;
+
+  public on(
+    event:
+      | "project_column"
+      | "project_column.created"
+      | "project_column.deleted"
+      | "project_column.edited"
+      | "project_column.moved",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadProjectColumn>
+    ) => void
+  ): void;
+
+  public on(
+    event:
+      | "project"
+      | "project.closed"
+      | "project.created"
+      | "project.deleted"
+      | "project.edited"
+      | "project.reopened",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadProject>) => void
+  ): void;
+
+  public on(
+    event: "public",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadPublic>) => void
+  ): void;
+
+  public on(
+    event:
+      | "pull_request"
+      | "pull_request.assigned"
+      | "pull_request.closed"
+      | "pull_request.edited"
+      | "pull_request.labeled"
+      | "pull_request.opened"
+      | "pull_request.reopened"
+      | "pull_request.review_request_removed"
+      | "pull_request.review_requested"
+      | "pull_request.unassigned"
+      | "pull_request.unlabeled"
+      | "pull_request.synchronize",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadPullRequest>) => void
+  ): void;
+
+  public on(
+    event:
+      | "pull_request_review"
+      | "pull_request_review.dismissed"
+      | "pull_request_review.edited"
+      | "pull_request_review.submitted",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadPullRequestReview>
+    ) => void
+  ): void;
+
+  public on(
+    event:
+      | "pull_request_review_comment"
+      | "pull_request_review_comment.created"
+      | "pull_request_review_comment.deleted"
+      | "pull_request_review_comment.edited",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadPullRequestReviewComment>
+    ) => void
+  ): void;
+
+  public on(
+    event: "push",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadPush>) => void
+  ): void;
+
+  public on(
+    event: "release" | "release.published",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadRelease>) => void
+  ): void;
+
+  public on(
+    event:
+      | "repository"
+      | "repository.archived"
+      | "repository.created"
+      | "repository.deleted"
+      | "repository.privatized"
+      | "repository.publicized"
+      | "repository.unarchived",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadRepository>) => void
+  ): void;
+
+  public on(
+    event: "repository_import",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadRepositoryImport>
+    ) => void
+  ): void;
+
+  public on(
+    event:
+      | "repository_vulnerability_alert"
+      | "repository_vulnerability_alert.create"
+      | "repository_vulnerability_alert.dismiss"
+      | "repository_vulnerability_alert.resolve",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadRepositoryVulnerabilityAlert>
+    ) => void
+  ): void;
+
+  public on(
+    event:
+      | "security_advisory"
+      | "security_advisory.performed"
+      | "security_advisory.published"
+      | "security_advisory.updated",
+    callback: (
+      event: Webhooks.WebhookEvent<WebhookPayloadSecurityAdvisory>
+    ) => void
+  ): void;
+
+  public on(
+    event: "status",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadStatus>) => void
+  ): void;
+
+  public on(
+    event:
+      | "team"
+      | "team.added_to_repository"
+      | "team.created"
+      | "team.deleted"
+      | "team.edited"
+      | "team.removed_from_repository",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadTeam>) => void
+  ): void;
+
+  public on(
+    event: "team_add",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadTeamAdd>) => void
+  ): void;
+
+  public on(
+    event: "watch" | "watch.started",
+    callback: (event: Webhooks.WebhookEvent<WebhookPayloadWatch>) => void
+  ): void;
+
+  public sign(data: any): string;
+  public verify(eventPayload: any, signature: string): boolean;
+  public verifyAndReceive(options: {
+    id: string;
+    name: string;
+    payload: any;
+    signature: string;
+  }): Promise<void>;
+  public receive(options: {
+    id: string;
+    name: string;
+    payload: any;
+  }): Promise<void>;
+  public removeListener(
+    event: string | string[],
+    callback: (event: Webhooks.WebhookEvent<any>) => void
+  ): void;
+  public removeListener(
+    event: string | string[],
+    callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>
+  ): void;
+  public middleware(
+    request: http.ClientRequest,
+    response: http.ServerResponse,
+    next: (err?: any) => void
+  ): (request: http.IncomingMessage, response: http.ServerResponse) => void;
+}
+
+export = Webhooks;

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -51,23 +51,26 @@ export namespace Webhooks {
     host?: string
     url?: string
   }
-  export class Webhooks {
-    constructor (options: Options)
-
-    public on (event: 'error', callback: (event: Error) => void): void
-    public on (event: '*' | string | string[], callback: (event: Webhooks.WebhookEvent<any>) => void): void
-    public on (event: '*' | string | string[], callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>): void
-    ${signatures.join('\n')}
-
-    public sign (data: any): string
-    public verify (eventPayload: any, signature: string): boolean
-    public verifyAndReceive (options: { id: string, name: string, payload: any, signature: string }): Promise<void>
-    public receive (options: { id: string, name: string, payload: any }): Promise<void>
-    public removeListener (event: string | string[], callback: (event: Webhooks.WebhookEvent<any>) => void): void
-    public removeListener (event: string | string[], callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>): void
-    public middleware (request: http.ClientRequest, response: http.ServerResponse, next: (err?: any) => void): (request: http.IncomingMessage, response: http.ServerResponse) => void
-  }
 }
+
+export class Webhooks {
+  constructor (options: Options)
+
+  public on (event: 'error', callback: (event: Error) => void): void
+  public on (event: '*' | string | string[], callback: (event: Webhooks.WebhookEvent<any>) => void): void
+  public on (event: '*' | string | string[], callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>): void
+  ${signatures.join('\n')}
+
+  public sign (data: any): string
+  public verify (eventPayload: any, signature: string): boolean
+  public verifyAndReceive (options: { id: string, name: string, payload: any, signature: string }): Promise<void>
+  public receive (options: { id: string, name: string, payload: any }): Promise<void>
+  public removeListener (event: string | string[], callback: (event: Webhooks.WebhookEvent<any>) => void): void
+  public removeListener (event: string | string[], callback: (event: Webhooks.WebhookEvent<any>) => Promise<void>): void
+  public middleware (request: http.ClientRequest, response: http.ServerResponse, next: (err?: any) => void): (request: http.IncomingMessage, response: http.ServerResponse) => void
+}
+
+export = Webhooks
 `
 
 const filepath = 'index.d.ts'


### PR DESCRIPTION
This is how we do it in @octokit/rest. I don’t know if that’s the right way to do it, but this change was necessary in order to get https://github.com/probot/probot/pull/832 to work