### PR TITLE
Fix naming collision

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2567,18 +2567,16 @@ declare namespace Webhooks {
     updated_at: number;
     single_file_name: string;
   };
-  type WebhookPayloadInstallationRepositories =
-    | Array<WebhookPayloadInstallationRepositoriesItem>
-    | {
-        action: string;
-        installation: WebhookPayloadInstallationRepositoriesInstallation;
-        repository_selection: string;
-        repositories_added: Array<any>;
-        repositories_removed: Array<
-          WebhookPayloadInstallationRepositoriesRepositoriesRemovedItem
-        >;
-        sender: WebhookPayloadInstallationRepositoriesSender;
-      };
+  type WebhookPayloadInstallationRepositories = {
+    action: string;
+    installation: WebhookPayloadInstallationRepositoriesInstallation;
+    repository_selection: string;
+    repositories_added: Array<any>;
+    repositories_removed: Array<
+      WebhookPayloadInstallationRepositoriesRepositoriesRemovedItem
+    >;
+    sender: WebhookPayloadInstallationRepositoriesSender;
+  };
   type WebhookPayloadInstallationSender = {
     login: string;
     id: number;
@@ -2649,7 +2647,7 @@ declare namespace Webhooks {
   type WebhookPayloadInstallation = {
     action: string;
     installation: WebhookPayloadInstallationInstallation;
-    repositories: WebhookPayloadInstallationRepositories;
+    repositories: Array<WebhookPayloadInstallationRepositoriesItem>;
     sender: WebhookPayloadInstallationSender;
   };
   type WebhookPayloadGollumSender = {

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -16,7 +16,12 @@ webhooks.forEach(({ name, actions, examples }) => {
   const typeName = `WebhookPayload${pascalCase(name)}`
   tw.add(examples, {
     rootTypeName: typeName,
-    namedKeyPaths: { [`${typeName}.repository`]: 'PayloadRepository' }
+    namedKeyPaths: {
+      [`${typeName}.repository`]: 'PayloadRepository',
+      // This prevents a naming colision between the payload of a `installation_repositories` event
+      // and the `repositories` attribute of a `installation` event
+      'WebhookPayloadInstallation.repositories': 'WebhookPayloadInstallation_Repositories'
+    }
   })
 
   const events = [


### PR DESCRIPTION
There was a naming colision between the payload of a `installation_repositories` event and the `repositories` attribute of a `installation` event. This PR fixes it.

Closes https://github.com/octokit/webhooks.js/issues/59