### PR TITLE
Correct missing external reference to GitHub docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ webhooks.on(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of <a target="_blank" rel="noopener noreferrer" href="https://developer.github.com/webhooks/#events">GitHub’s supported event names</a>.
+      Name of the event. One of [GitHub’s supported event names](https://developer.github.com/webhooks/#events).
     </td>
   </tr>
   <tr>
@@ -407,7 +407,7 @@ webhooks.removeListener(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of <a target="_blank" rel="noopener noreferrer" href="https://developer.github.com/webhooks/#events">GitHub’s supported event names</a>.
+      Name of the event. One of [GitHub’s supported event names](https://developer.github.com/webhooks/#events).
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ webhooks.on(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of <a href="#listofalleventnames">GitHub’s supported event names</a>.
+      Name of the event. One of <a target="_blank" rel="noopener noreferrer" href="https://developer.github.com/webhooks/#events">GitHub’s supported event names</a>.
     </td>
   </tr>
   <tr>
@@ -407,7 +407,7 @@ webhooks.removeListener(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of <a href="#listofalleventnames">GitHub’s supported event names</a>.
+      Name of the event. One of <a target="_blank" rel="noopener noreferrer" href="https://developer.github.com/webhooks/#events">GitHub’s supported event names</a>.
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ webhooks.on(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of [GitHub’s supported event names](https://developer.github.com/webhooks/#events).
+      Name of the event. One of <a href="https://developer.github.com/webhooks/#events">GitHub's supported event names</a>.
     </td>
   </tr>
   <tr>
@@ -407,7 +407,7 @@ webhooks.removeListener(eventNames, handler)
     </td>
     <td>
       <strong>Required.</strong>
-      Name of the event. One of [GitHub’s supported event names](https://developer.github.com/webhooks/#events).
+      Name of the event. One of <a href="https://developer.github.com/webhooks/#events">GitHub’s supported event names</a>.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
The `README.md` is missing the correct URL to the GitHub docs

-----
[View rendered README.md](https://github.com/adamzerella/webhooks.js/blob/master/README.md)