### PR TITLE
Fix removeListener Iteration

### DIFF
--- a/event-handler/remove-listener.js
+++ b/event-handler/remove-listener.js
@@ -14,7 +14,7 @@ function receiverListener (state, webhookNameOrNames, handler) {
 
   // remove last hook that has been added, that way
   // it behaves the same as removeListener
-  for (let i = state.hooks[webhookNameOrNames].length; i > 0; i--) {
+  for (let i = state.hooks[webhookNameOrNames].length - 1; i >= 0; i--) {
     if (state.hooks[webhookNameOrNames][i] === handler) {
       state.hooks[webhookNameOrNames].splice(i, 1)
       return

--- a/test/unit/event-handler-remove-listener-test.js
+++ b/test/unit/event-handler-remove-listener-test.js
@@ -1,6 +1,6 @@
 const test = require('tap').test
 
-const receiverListener = require('../../event-handler/remove-listener')
+const removeListener = require('../../event-handler/remove-listener')
 
 test('remove-listener: single listener', t => {
   const push = () => {}
@@ -12,7 +12,7 @@ test('remove-listener: single listener', t => {
   }
 
   t.doesNotThrow(() => {
-    receiverListener(state, 'push', push)
+    removeListener(state, 'push', push)
   })
   t.deepEqual(state, { hooks: { push: [] } })
   t.end()
@@ -33,9 +33,9 @@ test('remove-listener: multiple listeners', t => {
   }
 
   t.doesNotThrow(() => {
-    receiverListener(state, 'push', push1)
-    receiverListener(state, 'push', push2)
-    receiverListener(state, 'push', push3)
+    removeListener(state, 'push', push1)
+    removeListener(state, 'push', push2)
+    removeListener(state, 'push', push3)
   })
   t.deepEqual(state, { hooks: { push: [], ping: [ping] } })
   t.end()

--- a/test/unit/event-handler-remove-listener-test.js
+++ b/test/unit/event-handler-remove-listener-test.js
@@ -1,0 +1,42 @@
+const test = require('tap').test
+
+const receiverListener = require('../../event-handler/remove-listener')
+
+test('remove-listener: single listener', t => {
+  const push = () => {}
+
+  const state = {
+    hooks: {
+      push: [push]
+    }
+  }
+
+  t.doesNotThrow(() => {
+    receiverListener(state, 'push', push)
+  })
+  t.deepEqual(state, { hooks: { push: [] } })
+  t.end()
+})
+
+test('remove-listener: multiple listeners', t => {
+  const push1 = () => {}
+  const push2 = () => {}
+  const push3 = () => {}
+
+  const ping = () => {}
+
+  const state = {
+    hooks: {
+      push: [push1, push2, push3],
+      ping: [ping]
+    }
+  }
+
+  t.doesNotThrow(() => {
+    receiverListener(state, 'push', push1)
+    receiverListener(state, 'push', push2)
+    receiverListener(state, 'push', push3)
+  })
+  t.deepEqual(state, { hooks: { push: [], ping: [ping] } })
+  t.end()
+})


### PR DESCRIPTION
The current implementation of [EventHandler#removeListener](https://github.com/octokit/webhooks.js/blob/27bdc45d150be445c36cba19ab686cd9a4cad0a6/event-handler/remove-listener.js#L17) never iterates to index `0` in the state.

---

Example code to reproduce this issue:

```js
const Octokit = require('@octokit/rest')
const Webhook = require('@octokit/webhooks')
const http = require('http')

const GITHUB_ORGANIZATION_NAME = ''
const GITHUB_ORGANIZATION_WEBHOOK_ID = 0
const GITHUB_ORGANIZATION_WEBHOOK_PATH = '/'
const GITHUB_ORGANIZATION_WEBHOOK_PORT= 8080
const GITHUB_ORGANIZATION_WEBHOOK_SECRET = ''
const GITHUB_PERSONAL_ACCESS_TOKEN = ''

const octokit = new Octokit({
  auth: GITHUB_PERSONAL_ACCESS_TOKEN
})

const webhook = new Webhook({
  path: GITHUB_ORGANIZATION_WEBHOOK_PATH,
  secret: GITHUB_ORGANIZATION_WEBHOOK_SECRET
})

const entrypoint = async () => {
  const listener = (event) => {
    webhook.removeListener('*', listener)
    console.log(`Received event: "${event.name}".`)
  }

  webhook.on('*', listener)

  await octokit.orgs.pingHook({
    org: GITHUB_ORGANIZATION_NAME,
    hook_id: GITHUB_ORGANIZATION_WEBHOOK_ID,
  })

  await octokit.orgs.pingHook({
    org: GITHUB_ORGANIZATION_NAME,
    hook_id: GITHUB_ORGANIZATION_WEBHOOK_ID,
  })
}

http.createServer(webhook.middleware)
  .listen(GITHUB_ORGANIZATION_WEBHOOK_PORT, () => entrypoint().catch(console.error))
```

Without the fix:
```
Received event: "ping".
Received event: "ping".
```
With the fix:
```
Received event: "ping".
```