### PR TITLE
Do not uppercase quoted escape sequences

### DIFF
--- a/sign/index.js
+++ b/sign/index.js
@@ -12,7 +12,7 @@ function sign (secret, payload) {
 }
 
 function toNormalizedJsonString (payload) {
-  return JSON.stringify(payload).replace(/\\u[\da-f]{4}/g, s => {
-    return s.substr(0, 2) + s.substr(2).toUpperCase()
+  return JSON.stringify(payload).replace(/[^\\]\\u[\da-f]{4}/g, s => {
+    return s.substr(0, 3) + s.substr(3).toUpperCase()
   })
 }

--- a/test/integration/verify-test.js
+++ b/test/integration/verify-test.js
@@ -59,6 +59,10 @@ test('verify(secret, eventPayload, signature) returns true if eventPayload conta
     foo: 'Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K'
   }, 'sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d')
   t.is(signatureMatchesUpperCaseSequence, true)
+  const signatureMatchesEscapedSequence = verify('development', {
+    foo: '\\u001b'
+  }, 'sha1=2c440a176f4cb84c8c921dfee882d594c2465097')
+  t.is(signatureMatchesEscapedSequence, true)
 
   t.end()
 })


### PR DESCRIPTION
If the payload contains text that starts with "\u", the replacer kicks
in and signature validation fails.

Attempt at improving the fix to #71