### PR TITLE
🐛 fix(type-writer): fix warning Prettier when running types generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,13 +153,13 @@
       }
     },
     "@gimenete/type-writer": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@gimenete/type-writer/-/type-writer-0.1.3.tgz",
-      "integrity": "sha512-vhpvVfM/fYqb1aAnkgOvtDKoOgU3ZYIvDnKSDAFSoBvallmGURMlHOE0/VG/gqunUZVXGCFBGHxI8swjBh+sIA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@gimenete/type-writer/-/type-writer-0.1.5.tgz",
+      "integrity": "sha512-ZeVljCBixwIU4MG3Kqy/3Dc7zfIMCj9kXyCQ6hiutwFqZkTWggrhqNSEc+NfN2ztLjUG+ssdFe7PUcCIXv67aA==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
-        "prettier": "^1.13.7"
+        "prettier": "^1.19.1"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debug": "^4.0.0"
   },
   "devDependencies": {
-    "@gimenete/type-writer": "^0.1.3",
+    "@gimenete/type-writer": "^0.1.5",
     "@octokit/webhooks-definitions": "3.3.0",
     "axios": "^0.19.0",
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To upgrade `@gimenete/type-writer` to the latest version

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix Prettier `warning` when generating types:
```bash
 { parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.
```

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. `npm run generate-types` using `@gimenete/type-writer v0.1.3` to see the warning
2. upgrade to latest @gimenete/type-writer v0.1.5"
3. validate the warning is not happening anymore

## 📸 Screenshots:
### Before
![image](https://user-images.githubusercontent.com/2574275/76964147-89cdec80-6922-11ea-8980-3006ba9003b5.png)

### After
![image](https://user-images.githubusercontent.com/2574275/76964249-b41faa00-6922-11ea-8ec6-49d975008784.png)

## 📚 References:
<!-- Any interesting external link to documentation, article, tweet which can add value to the PR -->
PR fixing the issue on type-writer: https://github.com/gimenete/type-writer/pull/4
Prettier parser deprecation references:
* https://prettier.io/docs/en/options.html#parser
* https://prettier.io/blog/2019/01/20/1.16.0.html#rename-babylon-parser-to-babel-5647-by-wuweiweiwu 