### PR TITLE
📦 refactor(library): migrate  entry point of all modules to lib/index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,13 @@
+const { createEventHandler } = require("../src/event-handler");
+const { createMiddleware } = require("../src/middleware");
+const { createWebhooksApi } = require("../src");
+const { sign } = require("../src/sign");
+const { verify } = require("../src/verify");
+
+export {
+	createEventHandler,
+	createMiddleware,
+	createWebhooksApi,
+	sign,
+	verify,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,10 @@ const { createWebhooksApi } = require("../src");
 const { sign } = require("../src/sign");
 const { verify } = require("../src/verify");
 
-export {
+module.exports = {
 	createEventHandler,
 	createMiddleware,
 	createWebhooksApi,
 	sign,
-	verify,
-};
+	verify
+}

--- a/src/event-handler/index.js
+++ b/src/event-handler/index.js
@@ -1,10 +1,15 @@
-module.exports = createEventHandler;
+const { deprecate } = require("util");
+
+module.exports = deprecate(
+  createEventHandler,
+  "src/event-handler/index.js is deprecated. Use lib/index.js instead."
+);
 
 const on = require("./on");
 const receive = require("./receive");
 const removeListener = require("./remove-listener");
 
-function createEventHandler(options) {
+export function createEventHandler(options) {
   const state = {
     hooks: {},
   };

--- a/src/event-handler/index.js
+++ b/src/event-handler/index.js
@@ -3,7 +3,7 @@
 const { deprecate } = require("util");
 module.exports = deprecate(
   createEventHandler,
-  "src/event-handler/index.js is deprecated. Use lib/index.js instead."
+  "const createEventHandler = require('@octokit/webhooks/event-handler') is deprecated. Use const { createEventHandler } = require('@octokit/webhooks')"
 );
 
 const on = require("./on");

--- a/src/event-handler/index.js
+++ b/src/event-handler/index.js
@@ -1,5 +1,6 @@
-const { deprecate } = require("util");
+// "use strict";
 
+const { deprecate } = require("util");
 module.exports = deprecate(
   createEventHandler,
   "src/event-handler/index.js is deprecated. Use lib/index.js instead."
@@ -9,7 +10,7 @@ const on = require("./on");
 const receive = require("./receive");
 const removeListener = require("./remove-listener");
 
-export function createEventHandler(options) {
+function createEventHandler(options) {
   const state = {
     hooks: {},
   };
@@ -24,3 +25,5 @@ export function createEventHandler(options) {
     receive: receive.bind(null, state),
   };
 }
+
+module.exports.createEventHandler = createEventHandler;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { deprecate } = require("util");
 
 module.exports = deprecate(
   createWebhooksApi,
-  "src/index.js is deprecated. Use lib/index.js instead."
+  "const createWebhooksApi = require('@octokit/webhooks') is deprecated. Use const { createWebhooksApi } = require('@octokit/webhooks')"
 );
 
 const { createEventHandler } = require("./event-handler");

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,10 @@ module.exports = deprecate(
 const { createEventHandler } = require("./event-handler");
 const middleware = require("./middleware/middleware");
 const { sign } = require("./sign");
-const verify = require("./verify");
+const { verify } = require("./verify");
 const verifyAndReceive = require("./middleware/verify-and-receive");
 
-export function createWebhooksApi(options) {
+function createWebhooksApi(options) {
   if (!options || !options.secret) {
     throw new Error("options.secret required");
   }
@@ -32,3 +32,5 @@ export function createWebhooksApi(options) {
     verifyAndReceive: verifyAndReceive.bind(null, state),
   };
 }
+
+module.exports.createWebhooksApi = createWebhooksApi;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,17 @@
-module.exports = createWebhooksApi;
+const { deprecate } = require("util");
 
-const createEventHandler = require("./event-handler");
+module.exports = deprecate(
+  createWebhooksApi,
+  "src/index.js is deprecated. Use lib/index.js instead."
+);
+
+const { createEventHandler } = require("./event-handler");
 const middleware = require("./middleware/middleware");
-const sign = require("./sign");
+const { sign } = require("./sign");
 const verify = require("./verify");
 const verifyAndReceive = require("./middleware/verify-and-receive");
 
-function createWebhooksApi(options) {
+export function createWebhooksApi(options) {
   if (!options || !options.secret) {
     throw new Error("options.secret required");
   }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -4,13 +4,13 @@ const { deprecate } = require("util");
 
 module.exports = deprecate(
   createMiddleware,
-  "src/event-handler/index.js is deprecated. Use lib/index.js instead."
+  "src/middleware/index.js is deprecated. Use lib/index.js instead."
 );
 
 const { createEventHandler } = require("../event-handler");
 const middleware = require("./middleware");
 
-export function createMiddleware(options) {
+function createMiddleware(options) {
   if (!options || !options.secret) {
     throw new Error("options.secret required");
   }
@@ -28,3 +28,5 @@ export function createMiddleware(options) {
 
   return api;
 }
+
+module.exports.createMiddleware = createMiddleware;

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -4,7 +4,7 @@ const { deprecate } = require("util");
 
 module.exports = deprecate(
   createMiddleware,
-  "src/middleware/index.js is deprecated. Use lib/index.js instead."
+  "const createMiddleware = require('@octokit/webhooks/middleware') is deprecated. Use const { createMiddleware } = require('@octokit/webhooks')"
 );
 
 const { createEventHandler } = require("../event-handler");

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,11 +1,16 @@
 "use strict";
 
-module.exports = createMiddleware;
+const { deprecate } = require("util");
 
-const createEventHandler = require("../event-handler");
+module.exports = deprecate(
+  createMiddleware,
+  "src/event-handler/index.js is deprecated. Use lib/index.js instead."
+);
+
+const { createEventHandler } = require("../event-handler");
 const middleware = require("./middleware");
 
-function createMiddleware(options) {
+export function createMiddleware(options) {
   if (!options || !options.secret) {
     throw new Error("options.secret required");
   }

--- a/src/middleware/verify-and-receive.js
+++ b/src/middleware/verify-and-receive.js
@@ -1,6 +1,6 @@
 module.exports = verifyAndReceive;
 
-const verify = require("../verify");
+const { verify } = require("../verify");
 
 function verifyAndReceive(state, event) {
   const matchesSignature = verify(state.secret, event.payload, event.signature);

--- a/src/sign/index.js
+++ b/src/sign/index.js
@@ -7,7 +7,7 @@ module.exports = deprecate(
 
 const crypto = require("crypto");
 
-export function sign(secret, payload) {
+function sign(secret, payload) {
   if (!secret || !payload) {
     throw new TypeError("secret & payload required");
   }
@@ -24,3 +24,5 @@ function toNormalizedJsonString(payload) {
     return s.substr(0, 3) + s.substr(3).toUpperCase();
   });
 }
+
+module.exports.sign = sign;

--- a/src/sign/index.js
+++ b/src/sign/index.js
@@ -1,8 +1,13 @@
-module.exports = sign;
+const { deprecate } = require("util");
+
+module.exports = deprecate(
+  sign,
+  "src/sign/index.js is deprecated. Use lib/index.js instead."
+);
 
 const crypto = require("crypto");
 
-function sign(secret, payload) {
+export function sign(secret, payload) {
   if (!secret || !payload) {
     throw new TypeError("secret & payload required");
   }

--- a/src/sign/index.js
+++ b/src/sign/index.js
@@ -2,7 +2,7 @@ const { deprecate } = require("util");
 
 module.exports = deprecate(
   sign,
-  "src/sign/index.js is deprecated. Use lib/index.js instead."
+  "const sign = require('@octokit/webhooks/sign') is deprecated. Use const { sign } = require('@octokit/webhooks')"
 );
 
 const crypto = require("crypto");

--- a/src/verify/index.js
+++ b/src/verify/index.js
@@ -10,7 +10,7 @@ const Buffer = require("buffer").Buffer;
 
 const { sign } = require("../sign");
 
-export function verify(secret, eventPayload, signature) {
+function verify(secret, eventPayload, signature) {
   if (!secret || !eventPayload || !signature) {
     throw new TypeError("secret, eventPayload & signature required");
   }
@@ -29,3 +29,5 @@ export function verify(secret, eventPayload, signature) {
 function timingSafeEqual(signatureBuffer, verificationBuffer) {
   return crypto.timingSafeEqual(signatureBuffer, verificationBuffer);
 }
+
+module.exports.verify = verify;

--- a/src/verify/index.js
+++ b/src/verify/index.js
@@ -1,11 +1,16 @@
-module.exports = verify;
+const { deprecate } = require("util");
+
+module.exports = deprecate(
+  verify,
+  "src/verify/index.js is deprecated. Use lib/index.js instead."
+);
 
 const crypto = require("crypto");
 const Buffer = require("buffer").Buffer;
 
-const sign = require("../sign");
+const { sign } = require("../sign");
 
-function verify(secret, eventPayload, signature) {
+export function verify(secret, eventPayload, signature) {
   if (!secret || !eventPayload || !signature) {
     throw new TypeError("secret, eventPayload & signature required");
   }

--- a/src/verify/index.js
+++ b/src/verify/index.js
@@ -2,7 +2,7 @@ const { deprecate } = require("util");
 
 module.exports = deprecate(
   verify,
-  "src/verify/index.js is deprecated. Use lib/index.js instead."
+  "const verify = require('@octokit/webhooks/verify') is deprecated. Use const { verify } = require('@octokit/webhooks')"
 );
 
 const crypto = require("crypto");

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -1,0 +1,52 @@
+const test = require("tap").test;
+
+test("@octokit/webhooks", (t) => {
+  const createWebhooksApi = require("../../src");
+  const api = createWebhooksApi({ secret: "mysecret" });
+
+  t.type(api.sign, "function");
+  t.type(api.verify, "function");
+  t.type(api.on, "function");
+  t.type(api.removeListener, "function");
+  t.type(api.receive, "function");
+  t.type(api.middleware, "function");
+  t.type(api.verifyAndReceive, "function");
+
+  t.end();
+});
+
+test('require("@octokit/webhooks/sign")', (t) => {
+  t.doesNotThrow(() => {
+	const sign = require("../../src/sign");
+	sign('1234', {})
+  });
+
+  t.end();
+});
+
+test('require("@octokit/webhooks/verify")', (t) => {
+  t.doesNotThrow(() => {
+	const verify = require("../../src/verify");
+	verify('1234', {}, 'randomSignature')
+  });
+
+  t.end();
+});
+
+test('require("@octokit/webhooks/event-handler")', (t) => {
+  t.doesNotThrow(() => {
+	const createEventHandler = require("../../src/event-handler");
+	createEventHandler()
+  });
+
+  t.end();
+});
+
+test('require("@octokit/webhooks/middleware")', (t) => {
+  t.doesNotThrow(() => {
+	const createMiddleware = require("../../src/middleware");
+	createMiddleware({ secret: '1234' })
+  });
+
+  t.end();
+});

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -17,8 +17,8 @@ test("@octokit/webhooks", (t) => {
 
 test('require("@octokit/webhooks/sign")', (t) => {
   t.doesNotThrow(() => {
-	const sign = require("../../src/sign");
-	sign('1234', {})
+    const sign = require("../../src/sign");
+    sign("1234", {});
   });
 
   t.end();
@@ -26,8 +26,8 @@ test('require("@octokit/webhooks/sign")', (t) => {
 
 test('require("@octokit/webhooks/verify")', (t) => {
   t.doesNotThrow(() => {
-	const verify = require("../../src/verify");
-	verify('1234', {}, 'randomSignature')
+    const verify = require("../../src/verify");
+    verify("1234", {}, "randomSignature");
   });
 
   t.end();
@@ -35,8 +35,8 @@ test('require("@octokit/webhooks/verify")', (t) => {
 
 test('require("@octokit/webhooks/event-handler")', (t) => {
   t.doesNotThrow(() => {
-	const createEventHandler = require("../../src/event-handler");
-	createEventHandler()
+    const createEventHandler = require("../../src/event-handler");
+    createEventHandler();
   });
 
   t.end();
@@ -44,8 +44,8 @@ test('require("@octokit/webhooks/event-handler")', (t) => {
 
 test('require("@octokit/webhooks/middleware")', (t) => {
   t.doesNotThrow(() => {
-	const createMiddleware = require("../../src/middleware");
-	createMiddleware({ secret: '1234' })
+    const createMiddleware = require("../../src/middleware");
+    createMiddleware({ secret: "1234" });
   });
 
   t.end();

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -1,9 +1,13 @@
 const test = require("tap").test;
+const { mock } = require("simple-mock");
 
 test("@octokit/webhooks", (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   const createWebhooksApi = require("../../src");
   const api = createWebhooksApi({ secret: "mysecret" });
 
+  t.true(emitWarningMock.called);
+  t.equals(emitWarningMock.callCount, 1);
   t.type(api.sign, "function");
   t.type(api.verify, "function");
   t.type(api.on, "function");
@@ -16,37 +20,53 @@ test("@octokit/webhooks", (t) => {
 });
 
 test('require("@octokit/webhooks/sign")', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   t.doesNotThrow(() => {
     const sign = require("../../src/sign");
     sign("1234", {});
   });
 
+  t.true(emitWarningMock.called);
+  t.equals(emitWarningMock.callCount, 1);
+
   t.end();
 });
 
 test('require("@octokit/webhooks/verify")', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   t.doesNotThrow(() => {
     const verify = require("../../src/verify");
     verify("1234", {}, "randomSignature");
   });
 
+  t.true(emitWarningMock.called);
+  t.equals(emitWarningMock.callCount, 1);
+
   t.end();
 });
 
 test('require("@octokit/webhooks/event-handler")', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   t.doesNotThrow(() => {
     const createEventHandler = require("../../src/event-handler");
     createEventHandler();
   });
 
+  t.true(emitWarningMock.called);
+  t.equals(emitWarningMock.callCount, 1);
+
   t.end();
 });
 
 test('require("@octokit/webhooks/middleware")', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   t.doesNotThrow(() => {
     const createMiddleware = require("../../src/middleware");
     createMiddleware({ secret: "1234" });
   });
+
+  t.true(emitWarningMock.called);
+  t.equals(emitWarningMock.callCount, 1);
 
   t.end();
 });

--- a/test/integration/event-handler-test.js
+++ b/test/integration/event-handler-test.js
@@ -1,13 +1,13 @@
 const test = require("tap").test;
 
-const EventHandler = require("../../src/event-handler");
+const { createEventHandler } = require("../../lib");
 const pushEventPayload = require("../fixtures/push-payload");
 const installationCreatedPayload = require("../fixtures/installation-created-payload");
 
 test("events", (t) => {
   t.plan(6);
 
-  const eventHandler = new EventHandler();
+  const eventHandler = createEventHandler();
 
   const hooksCalled = [];
   function hook1() {
@@ -99,7 +99,7 @@ test("events", (t) => {
 test("options.transform", (t) => {
   t.plan(2);
 
-  const eventHandler = EventHandler({
+  const eventHandler = createEventHandler({
     transform: (event) => {
       t.is(event.id, "123");
       return "funky";
@@ -118,7 +118,7 @@ test("options.transform", (t) => {
 });
 
 test("async options.transform", (t) => {
-  const eventHandler = EventHandler({
+  const eventHandler = createEventHandler({
     transform: (event) => {
       return Promise.resolve("funky");
     },

--- a/test/integration/middleware-test.js
+++ b/test/integration/middleware-test.js
@@ -4,7 +4,7 @@ const Buffer = require("buffer").Buffer;
 const test = require("tap").test;
 const simple = require("simple-mock");
 
-const createMiddleware = require("../../src/middleware");
+const { createMiddleware } = require("../../lib");
 
 const headers = {
   "x-github-delivery": "123e4567-e89b-12d3-a456-426655440000",

--- a/test/integration/sign-test.js
+++ b/test/integration/sign-test.js
@@ -1,6 +1,6 @@
 const test = require("tap").test;
 
-const sign = require("../../src/sign");
+const { sign } = require("../../lib");
 
 const eventPayload = {
   foo: "bar",

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -1,6 +1,8 @@
 const test = require("tap").test;
+const { mock } = require("simple-mock");
 
 test("@octokit/webhooks", (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
   const { createWebhooksApi } = require("../../lib");
   const api = createWebhooksApi({ secret: "mysecret" });
 
@@ -11,42 +13,55 @@ test("@octokit/webhooks", (t) => {
   t.type(api.receive, "function");
   t.type(api.middleware, "function");
   t.type(api.verifyAndReceive, "function");
+  t.false(emitWarningMock.called);
 
   t.end();
 });
 
 test('require("@octokit/webhooks").sign', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
+
   t.doesNotThrow(() => {
     const { sign } = require("../../lib");
     sign("1234", {});
   });
+  t.false(emitWarningMock.called);
 
   t.end();
 });
 
 test('require("@octokit/webhooks").verify', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
+
   t.doesNotThrow(() => {
     const { verify } = require("../../lib");
     verify("1234", {}, "randomSignature");
   });
+  t.false(emitWarningMock.called);
 
   t.end();
 });
 
 test('require("@octokit/webhooks").createEventHandler', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
+
   t.doesNotThrow(() => {
     const { createEventHandler } = require("../../lib");
     createEventHandler();
   });
+  t.false(emitWarningMock.called);
 
   t.end();
 });
 
 test('require("@octokit/webhooks).createMiddleware")', (t) => {
+  const emitWarningMock = mock(process, "emitWarning");
+
   t.doesNotThrow(() => {
     const { createMiddleware } = require("../../lib");
     createMiddleware({ secret: "1234" });
   });
+  t.false(emitWarningMock.called);
 
   t.end();
 });

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -18,7 +18,7 @@ test("@octokit/webhooks", (t) => {
 test('require("@octokit/webhooks").sign', (t) => {
   t.doesNotThrow(() => {
     const { sign } = require("../../lib");
-    sign('1234', {});
+    sign("1234", {});
   });
 
   t.end();
@@ -27,7 +27,7 @@ test('require("@octokit/webhooks").sign', (t) => {
 test('require("@octokit/webhooks").verify', (t) => {
   t.doesNotThrow(() => {
     const { verify } = require("../../lib");
-    verify('1234', {}, 'randomSignature')
+    verify("1234", {}, "randomSignature");
   });
 
   t.end();
@@ -45,7 +45,7 @@ test('require("@octokit/webhooks").createEventHandler', (t) => {
 test('require("@octokit/webhooks).createMiddleware")', (t) => {
   t.doesNotThrow(() => {
     const { createMiddleware } = require("../../lib");
-    createMiddleware({ secret: '1234' })
+    createMiddleware({ secret: "1234" });
   });
 
   t.end();

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -1,8 +1,8 @@
 const test = require("tap").test;
 
 test("@octokit/webhooks", (t) => {
-  const Webhooks = require("../..");
-  const api = new Webhooks({ secret: "mysecret" });
+  const { createWebhooksApi } = require("../../lib");
+  const api = createWebhooksApi({ secret: "mysecret" });
 
   t.type(api.sign, "function");
   t.type(api.verify, "function");
@@ -15,33 +15,37 @@ test("@octokit/webhooks", (t) => {
   t.end();
 });
 
-test('require("@octokit/webhooks/sign")', (t) => {
+test('require("@octokit/webhooks").sign', (t) => {
   t.doesNotThrow(() => {
-    require("../../src/sign");
+    const { sign } = require("../../lib");
+    sign('1234', {});
   });
 
   t.end();
 });
 
-test('require("@octokit/webhooks/verify")', (t) => {
+test('require("@octokit/webhooks").verify', (t) => {
   t.doesNotThrow(() => {
-    require("../../src/verify");
+    const { verify } = require("../../lib");
+    verify('1234', {}, 'randomSignature')
   });
 
   t.end();
 });
 
-test('require("@octokit/webhooks/event-handler")', (t) => {
+test('require("@octokit/webhooks").createEventHandler', (t) => {
   t.doesNotThrow(() => {
-    require("../../src/event-handler");
+    const { createEventHandler } = require("../../lib");
+    createEventHandler();
   });
 
   t.end();
 });
 
-test('require("@octokit/webhooks/middleware")', (t) => {
+test('require("@octokit/webhooks).createMiddleware")', (t) => {
   t.doesNotThrow(() => {
-    require("../../src/middleware");
+    const { createMiddleware } = require("../../lib");
+    createMiddleware({ secret: '1234' })
   });
 
   t.end();

--- a/test/integration/verify-test.js
+++ b/test/integration/verify-test.js
@@ -1,6 +1,6 @@
 const test = require("tap").test;
 
-const verify = require("../../src/verify");
+const { verify } = require("../../lib");
 
 const eventPayload = {
   foo: "bar",

--- a/test/unit/middleware-constructor-test.js
+++ b/test/unit/middleware-constructor-test.js
@@ -1,8 +1,8 @@
 const test = require("tap").test;
 
-const Middleware = require("../../src/middleware");
+const { createMiddleware } = require("../../lib");
 
 test("options: none", (t) => {
-  t.throws(Middleware);
+  t.throws(createMiddleware);
   t.end();
 });


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Change entry point for all modules to `lib/index.js`
- Keep retrocompatibility but warn the user about a future deprecation

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/octokit/webhooks.js/pull/113