### PR TITLE
🐛 fix(declaration-type): fix missing return type on createWebhooksApi

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5001,7 +5001,7 @@ declare class Webhooks {
   ): void | Promise<void>;
 }
 
-export function createWebhooksApi(options?: Options);
+export function createWebhooksApi(options?: Options): Webhooks;
 
 export default Webhooks;
 export { Webhooks };

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -75,7 +75,7 @@ declare class Webhooks {
   public middleware (request: http.IncomingMessage, response: http.ServerResponse, next?: (err?: any) => void): void | Promise<void>
 }
 
-export function createWebhooksApi(options?: Options);
+export function createWebhooksApi(options?: Options): Webhooks;
 
 export default Webhooks;
 export { Webhooks };

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,4 +1,4 @@
-import * as Webhooks from "..";
+import Webhooks from "..";
 import { createServer } from "http";
 
 // ************************************************************


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Add missing return type of `createWebhookApi` on `index.d.ts`
- Adapt `typescript-validate` to import `index.d.ts` properly

Fixes #136

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Creating a dummy `index.ts` using the library and trying to compile it using `tsc` before and after applying the fix.

### Before
![image](https://user-images.githubusercontent.com/2574275/82101206-30105580-970c-11ea-9894-219037993ad7.png)
![image](https://user-images.githubusercontent.com/2574275/82101253-56ce8c00-970c-11ea-8f1c-7f8a4d948c9c.png)

### After 
![image](https://user-images.githubusercontent.com/2574275/82101266-5d5d0380-970c-11ea-8c4f-23c685e0a8ce.png)