### PR TITLE
🐛 fix(type-declaration): add missing new named exports to generated types (index.d.ts): sign, verif

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4891,6 +4891,10 @@ declare class Webhooks {
 }
 
 export function createWebhooksApi(options?: Options): Webhooks;
+export function createEventHandler(options?: Options): Webhooks;
+export function createMiddleware(options?: Options): Webhooks;
+export function sign(data: any): string;
+export function verify(eventPayload: any, signature: string): boolean;
 
 export default Webhooks;
 export { Webhooks };

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -90,6 +90,10 @@ declare class Webhooks {
 }
 
 export function createWebhooksApi(options?: Options): Webhooks;
+export function createEventHandler(options?: Options): Webhooks;
+export function createMiddleware(options?: Options): Webhooks;
+export function sign(data: any): string
+export function verify(eventPayload: any, signature: string): boolean
 
 export default Webhooks;
 export { Webhooks };

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,4 +1,10 @@
-import Webhooks from "..";
+import Webhooks, {
+  createEventHandler,
+  createMiddleware,
+  createWebhooksApi,
+  sign,
+  verify
+} from "..";
 import { createServer } from "http";
 
 // ************************************************************
@@ -20,6 +26,22 @@ export default async function () {
     path: "/webhooks",
     transform: (event) => event,
   });
+
+  // Check named expors of new API work
+  createWebhooksApi({
+    secret: 'bleh'
+  });
+
+  createEventHandler({ secret: 'bleh' });
+
+  createMiddleware({
+    secret: 'mysecret',
+    path: '/github-webhooks'
+  });
+
+  sign({});
+
+  verify({}, 'randomSignature');
 
   webhooks.on("*", ({ id, name, payload }) => {
     console.log(name, "event received");

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -3,7 +3,7 @@ import Webhooks, {
   createMiddleware,
   createWebhooksApi,
   sign,
-  verify
+  verify,
 } from "..";
 import { createServer } from "http";
 
@@ -29,19 +29,19 @@ export default async function () {
 
   // Check named expors of new API work
   createWebhooksApi({
-    secret: 'bleh'
+    secret: "bleh",
   });
 
-  createEventHandler({ secret: 'bleh' });
+  createEventHandler({ secret: "bleh" });
 
   createMiddleware({
-    secret: 'mysecret',
-    path: '/github-webhooks'
+    secret: "mysecret",
+    path: "/github-webhooks",
   });
 
   sign({});
 
-  verify({}, 'randomSignature');
+  verify({}, "randomSignature");
 
   webhooks.on("*", ({ id, name, payload }) => {
     console.log(name, "event received");


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Added missing named exports from latest changes on API to type declaration (`index.d.ts`):
* `verify`
* `sign`
* `createMiddleware`
* `createEventHandler`

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During the migration to new API giving support for named imports for main utility functions of this library it was not applied to `index.d.ts` type declaration accordingly. (https://github.com/octokit/webhooks.js/pull/126 and https://github.com/octokit/webhooks.js/pull/137)

Fix #152 