### PR TITLE
Fixing dead links to receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ webhooks.receive({ id, name, payload });
 
 Returns a promise. Runs all handlers set with [`webhooks.on()`](#webhookson) in parallel and waits for them to finish. If one of the handlers rejects or throws an error, then `webhooks.receive()` rejects. The returned error has an `.errors` property which holds an array of all errors caught from the handlers. If no errors occur, `webhooks.receive()` resolves without passing any value.
 
-The `.receive()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
+The `.receive()` method belongs to the `event-handler` module which can be used [standalone](src/event-handler/).
 
 ### webhooks.on()
 
@@ -388,7 +388,7 @@ webhooks.on(eventNames, handler);
   </tr>
 </table>
 
-The `.on()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
+The `.on()` method belongs to the `event-handler` module which can be used [standalone](src/event-handler/).
 
 ### webhooks.removeListener()
 
@@ -442,7 +442,7 @@ webhooks.removeListener(eventNames, handler);
   </tr>
 </table>
 
-The `.removeListener()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
+The `.removeListener()` method belongs to the `event-handler` module which can be used [standalone](src/event-handler/).
 
 ### webhooks.middleware()
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ webhooks.receive({ id, name, payload });
 
 Returns a promise. Runs all handlers set with [`webhooks.on()`](#webhookson) in parallel and waits for them to finish. If one of the handlers rejects or throws an error, then `webhooks.receive()` rejects. The returned error has an `.errors` property which holds an array of all errors caught from the handlers. If no errors occur, `webhooks.receive()` resolves without passing any value.
 
-The `.receive()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
+The `.receive()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
 
 ### webhooks.on()
 
@@ -388,7 +388,7 @@ webhooks.on(eventNames, handler);
   </tr>
 </table>
 
-The `.on()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
+The `.on()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
 
 ### webhooks.removeListener()
 
@@ -442,7 +442,7 @@ webhooks.removeListener(eventNames, handler);
   </tr>
 </table>
 
-The `.removeListener()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
+The `.removeListener()` method belongs to the [`EventHandler`](src/event-handler/) module which can be used standalone.
 
 ### webhooks.middleware()
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ webhooks.receive({ id, name, payload });
 
 Returns a promise. Runs all handlers set with [`webhooks.on()`](#webhookson) in parallel and waits for them to finish. If one of the handlers rejects or throws an error, then `webhooks.receive()` rejects. The returned error has an `.errors` property which holds an array of all errors caught from the handlers. If no errors occur, `webhooks.receive()` resolves without passing any value.
 
-The `.receive()` method belongs to the [receiver](receiver/) module which can be used standalone.
+The `.receive()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
 
 ### webhooks.on()
 
@@ -388,7 +388,7 @@ webhooks.on(eventNames, handler);
   </tr>
 </table>
 
-The `.on()` method belongs to the [receiver](receiver/) module which can be used standalone.
+The `.on()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
 
 ### webhooks.removeListener()
 
@@ -442,7 +442,7 @@ webhooks.removeListener(eventNames, handler);
   </tr>
 </table>
 
-The `.removeListener()` method belongs to the [receiver](receiver/) module which can be used standalone.
+The `.removeListener()` method belongs to the [`EventHandler`](event-handler/) module which can be used standalone.
 
 ### webhooks.middleware()
 


### PR DESCRIPTION
Updating references to `Recevier` to point users to the `EventHandler` module

Fixes #151 

-----
[View rendered README.md](https://github.com/SpencerKaiser/webhooks.js/blob/dead-link-2/README.md)