### PR TITLE
test: return type from `options.transform` should be used for `event` type in event handler

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -3,7 +3,7 @@ import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 import { Options, State } from "../types";
 
-export function createEventHandler(options: Options) {
+export function createEventHandler(options: Options<any>) {
   const state: State = {
     hooks: {},
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,16 +9,18 @@ import { EventNames } from "./generated/event-names";
 import { GetWebhookPayloadTypeFromEvent } from "./generated/get-webhook-payload-type-from-event";
 import { IncomingMessage, ServerResponse } from "http";
 
-class Webhooks {
+class Webhooks<T extends WebhookEvent = WebhookEvent> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload?: object, signature?: string) => boolean;
-  public on: <T extends EventNames.All>(
-    event: T | T[],
-    callback: (event: GetWebhookPayloadTypeFromEvent<T>) => Promise<void> | void
+  public on: <E extends EventNames.All>(
+    event: E | E[],
+    callback: (
+      event: GetWebhookPayloadTypeFromEvent<E> & T
+    ) => Promise<void> | void
   ) => void;
-  public removeListener: <T extends EventNames.All>(
-    event: T | T[],
-    callback: (event: GetWebhookPayloadTypeFromEvent<T>) => Promise<void> | void
+  public removeListener: <E extends EventNames.All>(
+    event: E | E[],
+    callback: (event: GetWebhookPayloadTypeFromEvent<E>) => Promise<void> | void
   ) => void;
   public receive: (options: {
     id: string;
@@ -34,7 +36,7 @@ class Webhooks {
     options: WebhookEvent & { signature: string }
   ) => Promise<void>;
 
-  constructor(options?: Options) {
+  constructor(options?: Options<T>) {
     if (!options || !options.secret) {
       throw new Error("options.secret required");
     }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -2,7 +2,7 @@ import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
 import { Options, State } from "../types";
 
-export function createMiddleware(options: Options) {
+export function createMiddleware(options: Options<any>) {
   if (!options || !options.secret) {
     throw new Error("options.secret required");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,17 +5,21 @@ export interface WebhookEvent<T = any> {
   payload: T;
 }
 
-export interface Options {
+export interface Options<T extends WebhookEvent> {
   path?: string;
   secret?: string;
-  transform?: (value: WebhookEvent) => WebhookEvent | PromiseLike<WebhookEvent>;
+  transform?: TransformMethod<T>;
 }
+
+type TransformMethod<T extends WebhookEvent> = (
+  event: WebhookEvent
+) => T | PromiseLike<T>;
 
 type Hooks = {
   [key: string]: Function[];
 };
 
-export interface State extends Options {
+export interface State extends Options<any> {
   eventHandler?: any;
   hooks: Hooks;
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -48,7 +48,7 @@ export default async function () {
     path: "/webhooks",
     transform: (event) => {
       console.log(event.payload);
-      return event;
+      return Object.assign(event, { foo: "bar" });
     },
   });
 
@@ -108,6 +108,11 @@ export default async function () {
 
   webhooks.on("issues", (event) => {
     console.log(event.payload.issue);
+  });
+
+  webhooks.on("issues", (event) => {
+    // foo is set by options.transform
+    console.log(event.foo);
   });
 
   createServer(webhooks.middleware).listen(3000);


### PR DESCRIPTION
This currently throws a type error

```ts
const webhooks = new Webhooks({
  secret: "bleh",
  path: "/webhooks",
  transform: (event) => Object.assign(event, { foo: "bar" })
});
webhooks.on("issues", (event) => {
  console.log(event.foo);
});
```

complaining that 

> Property 'foo' does not exist on type 'WebhookEvent<WebhookPayloadIssues>'

But that is not true, because the `foo` property is set in `options.transform`.

In a nutshell, I want the following:

1. If `options.transform` is not set, then set the `event` type in the `.on()` callback to the existing `WebhookEvent` type
2. If `options.transform` is set, then set the `event` type in the `.on()` callback to the the return/resolve type of `options.transform`

Here is a [TypeScript playground link for a minimal test case](https://www.staging-typescript.org/play?#code/PTAEHEHsEMBsGcBcAoEoCMA6UBJAZqJAA4AuAlpAHbyYkBO01ekdAtqGfKJZCaPAFMSAGlAkAFgMr8hYyaAEA3KXxIBPIgI7SJWzFQAUASlABjOLABG0UwGsxkOVoEAPTuUoBzUAHUBl8UhIWwBRZUpVDQFUMAAmbHxCUgpqWgYmFnZOGREnaUFVeSUVMSjtJ1B9SmMzC2s7BwrdUDohAFc6SmBW+EhYZVLNQgJicioaekZ4ZjZkZHUhvwCg0PCSAB4AFVAAXlBGNQA+XdAAb2RQS+5oVgFEUAByeHoyLwfhC6uiaDVYGAATe6bZAAXzmCy0YRUAGE6jZ7HsDMUIvcloFglCIiYdsdFJAyP95mVNulppkALJCQL-E5bBQuEhSf5cNErTEkQ5Itao-zo1YqbHHbYAH1AAAU6JBWJwBAAZMi2ARbQ5EoYAeWS4xO5yuYlJM1YAH4gfqKVTIISwchTLBoPAWbyVlwdV82pZYGRTIRqsiSPdnnRXp5RL6ABKMf6wAR0e7s2GwKzwkwu3WXNCYDOfS5W3Wmcb0NqmEgsAyjFLwY2gDVjajJrOp9OZ3Vgq156h8ADujuC8HQJ0oAg7vm7tngxmQXeWPawhgezEg7wUa12xxTZnGfQEmD+ni5KkwlBuAiMoJP1vzoEnfPgsX7g+HU9HBjXkwybD3WLO9d1rRIHWkaqWAAVgIRaYHa8BkJ4PprKIpygPO9wPNYdAPCCJ7NqeE4jjeVQGHOQSLr6K5frqaCbGqAAiar3Kw0CKnI2Qdiwtj1m2vRRtukC7r6mDzie6FAA)

I've posted the question on StackOverflow, too: https://stackoverflow.com/questions/63233585/derive-type-of-methods-callback-argument-from-constructor-options-return-type

---

This is currently blocking Probot v10: https://github.com/probot/probot/pull/1274