### PR TITLE
fix: assure that errors are always instances of AggregateError

### DIFF
--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -1,5 +1,4 @@
 import AggregateError from "aggregate-error";
-import { Deprecation } from "deprecation";
 
 import { wrapErrorHandler } from "./wrap-error-handler";
 import {

--- a/src/middleware/get-payload.ts
+++ b/src/middleware/get-payload.ts
@@ -1,3 +1,5 @@
+import AggregateError from "aggregate-error";
+
 import { IncomingMessage } from "http";
 
 export function getPayload(request: IncomingMessage): Promise<any> {
@@ -10,7 +12,7 @@ export function getPayload(request: IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = "";
 
-    request.on("error", reject);
+    request.on("error", (error) => reject(new AggregateError([error])));
     request.on("data", (chunk) => (data += chunk));
     request.on("end", () => {
       try {
@@ -18,7 +20,7 @@ export function getPayload(request: IncomingMessage): Promise<any> {
       } catch (error) {
         error.message = "Invalid JSON";
         error.status = 400;
-        reject(error);
+        reject(new AggregateError([error]));
       }
     });
   });

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -4,8 +4,9 @@ import { getPayload } from "./get-payload";
 import { verifyAndReceive } from "./verify-and-receive";
 import { debug } from "debug";
 import { IncomingMessage, ServerResponse } from "http";
-import { State } from "../types";
+import { State, OctokitError, WebhookEventHandlerError } from "../types";
 import { EventNames } from "../generated/event-names";
+import AggregateError from "aggregate-error";
 
 const debugWebhooks = debug("webhooks:receiver");
 
@@ -61,8 +62,9 @@ export function middleware(
       response.end("ok\n");
     })
 
-    .catch((error) => {
-      response.statusCode = error.status || 500;
+    .catch((error: WebhookEventHandlerError) => {
+      const statusCode = Array.from(error)[0].status;
+      response.statusCode = statusCode || 500;
       response.end(error.toString());
     });
 }

--- a/test/integration/middleware-test.js
+++ b/test/integration/middleware-test.js
@@ -23,7 +23,7 @@ test("Invalid payload", (t) => {
   const middleware = createMiddleware({ secret: "mysecret" });
   middleware(requestMock, responseMock).then(() => {
     t.is(responseMock.statusCode, 400);
-    t.is(responseMock.end.lastCall.arg, "SyntaxError: Invalid JSON");
+    t.match(responseMock.end.lastCall.arg, /SyntaxError: Invalid JSON/);
     t.end();
   });
 
@@ -44,7 +44,7 @@ test("request error", (t) => {
   const middleware = createMiddleware({ secret: "mysecret" });
   middleware(requestMock, responseMock).then(() => {
     t.is(responseMock.statusCode, 500);
-    t.is(responseMock.end.lastCall.arg, "Error: oops");
+    t.match(responseMock.end.lastCall.arg, /Error: oops/);
 
     t.end();
   });


### PR DESCRIPTION
This is something I run into with the latest Probot beta: https://github.com/probot/probot/pull/1274#issuecomment-670086584

@wolfy1339 @dominguezcelada I had to slightly adjust one existing test, so you might run into a conflict when rewriting the tests, sorry for that!