### PR TITLE
fix: set encoding before reading payload for signature verification

### DIFF
--- a/src/middleware/get-payload.ts
+++ b/src/middleware/get-payload.ts
@@ -12,6 +12,7 @@ export function getPayload(request: IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = "";
 
+    request.setEncoding("utf8");
     request.on("error", (error) => reject(new AggregateError([error])));
     request.on("data", (chunk) => (data += chunk));
     request.on("end", () => {

--- a/test/integration/middleware-test.js
+++ b/test/integration/middleware-test.js
@@ -15,6 +15,7 @@ test("Invalid payload", (t) => {
   requestMock.method = "POST";
   requestMock.headers = headers;
   requestMock.url = "/";
+  requestMock.setEncoding = function (encoding) {};
 
   const responseMock = {
     end: simple.spy(),
@@ -36,6 +37,7 @@ test("request error", (t) => {
   requestMock.method = "POST";
   requestMock.headers = headers;
   requestMock.url = "/";
+  requestMock.setEncoding = function (encoding) {};
 
   const responseMock = {
     end: simple.spy(),


### PR DESCRIPTION
Attempting to fix the signature mismatch errors seen by @gr2m in https://github.com/probot/probot/pull/1274.

When changed from javascript to typescript it looks like the body parsing of the IncomingMessage changed to a string and this may be causing encoding issues when generating the signatures to confirm authenticity of the webhook.