### PR TITLE
Fix sign test type compilation error

### DIFF
--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,10 +1,6 @@
 import { createHmac } from "crypto";
 
 export function sign(secret: string, payload: string | object): string {
-  if (!secret || !payload) {
-    throw new TypeError("secret & payload required");
-  }
-
   payload =
     typeof payload === "string" ? payload : toNormalizedJsonString(payload);
   return "sha1=" + createHmac("sha1", secret).update(payload).digest("hex");

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -5,19 +5,6 @@ const eventPayload = {
 };
 const secret = "mysecret";
 
-test("sign() without options throws", () => {
-  // @ts-ignore
-  expect(() => sign()).toThrow();
-});
-
-test("sign(undefined, eventPayload) without secret throws", () => {
-  expect(() => sign.bind(null, undefined, eventPayload)()).toThrow();
-});
-
-test("sign(secret) without eventPayload throws", () => {
-  expect(() => sign.bind(null, secret)()).toThrow();
-});
-
 test("sign(secret, eventPayload) with eventPayload as object returns expected signature", () => {
   const signature = sign(secret, eventPayload);
   expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");


### PR DESCRIPTION
Parameters are mandatory according to [documentation](https://github.com/octokit/webhooks.js/blob/master/src/sign/README.md) so no need to control parameters with TypeScript