### PR TITLE
fix(deps): Depend on aggregate-error 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@octokit/request-error": "^2.0.2",
     "@pika/plugin-ts-standard-pkg": "^0.9.2",
-    "aggregate-error": "^3.0.1",
+    "aggregate-error": "^3.1.0",
     "debug": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This was already encoded in the package-lock.json due to #227, but since package.json is the only one that gets published to consumers, it's important for this version update to be expressed in package.json since in fact 3.0.1 leads to a typescript compile error.

Fixes #235
