### PR TITLE
refactor(types.ts): allow handler functions to return any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,14 @@ import { middleware } from "./middleware/middleware";
 import { sign } from "./sign/index";
 import { verify } from "./verify/index";
 import { verifyAndReceive } from "./middleware/verify-and-receive";
-import { Options, State, WebhookEvent, WebhookError } from "./types";
+import {
+  Options,
+  State,
+  WebhookEvent,
+  WebhookError,
+  HandlerFunction,
+} from "./types";
 import { EventNames } from "./generated/event-names";
-import { GetWebhookPayloadTypeFromEvent } from "./generated/get-webhook-payload-type-from-event";
 import { IncomingMessage, ServerResponse } from "http";
 
 class Webhooks<T extends WebhookEvent = WebhookEvent> {
@@ -14,15 +19,11 @@ class Webhooks<T extends WebhookEvent = WebhookEvent> {
   public verify: (eventPayload?: object, signature?: string) => boolean;
   public on: <E extends EventNames.All>(
     event: E | E[],
-    callback: (
-      event: GetWebhookPayloadTypeFromEvent<E, T>
-    ) => Promise<void> | void
+    callback: HandlerFunction<E, T>
   ) => void;
   public removeListener: <E extends EventNames.All>(
     event: E | E[],
-    callback: (
-      event: GetWebhookPayloadTypeFromEvent<E, T>
-    ) => Promise<void> | void
+    callback: HandlerFunction<E, T>
   ) => void;
   public receive: (options: {
     id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { RequestError } from "@octokit/request-error";
 
 import type { EventNames } from "./generated/event-names";
+import { GetWebhookPayloadTypeFromEvent } from "./generated/get-webhook-payload-type-from-event";
 
 export interface WebhookEvent<T = any> {
   id: string;
@@ -17,6 +18,10 @@ export interface Options<T extends WebhookEvent> {
 type TransformMethod<T extends WebhookEvent> = (
   event: WebhookEvent
 ) => T | PromiseLike<T>;
+
+export type HandlerFunction<E, T> = (
+  event: GetWebhookPayloadTypeFromEvent<E, T>
+) => any;
 
 type Hooks = {
   [key: string]: Function[];

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -95,6 +95,14 @@ export default async function () {
     console.log(payload.check_run.conclusion, name);
   });
 
+  webhooks.on("check_run.created", () => {
+    return 2;
+  });
+
+  webhooks.on("check_run.created", () => {
+    return Promise.resolve(10);
+  });
+
   webhooks.removeListener("check_run.created", ({ name, payload }) => {
     console.log(payload.check_run.conclusion, name);
   });


### PR DESCRIPTION
Hey @gr2m 👋 , thought I'd give a typescript PR a shot.

Currently handler functions that are passed to `Webhooks.on` can only
return `void` or `Promise<void>`. The return values from these functions
are only used to wait for all handlers for a given webhook event to
finish before the promise returned from `Webhooks.receive` resolves (or
rejects if any of the handler functions error out).

This updates the type signature to allow handler functions to return
anything.

Since this type signature was used in both `Webhooks.on` and
`Webhooks.removeListener`, this PR adds named type called
`HandlerFunction<E, T>` in `types.ts` and adds test cases to
`typescript-validate.ts` for the more lax types.

Fixes #178 