### PR TITLE
feat(sign): support sha256 algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,38 +149,10 @@ Returns the `webhooks` API.
 ### webhooks.sign()
 
 ```js
-webhooks.sign(secret, eventPayload);
-webhooks.sign({ secret, algorithm }, eventPayload);
+webhooks.sign(eventPayload);
 ```
 
 <table width="100%">
-  <tr>
-    <td>
-      <code>
-        secret
-      </code>
-      <em>
-        (string)
-      </em>
-    </td>
-    <td>
-      <strong>Required.</strong>
-      secret to generated the signature
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <code>
-        algorithm
-      </code>
-      <em>
-        (string)
-      </em>
-    </td>
-    <td>
-      Algorithm to calculate signature. Can be set to `sha1` or `sha256`. Defaults to `sha1`.
-    </td>
-  </tr>
   <tr>
     <td>
       <code>

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Returns the `webhooks` API.
 
 ```js
 webhooks.sign(secret, eventPayload);
+webhooks.sign({ secret, algorithm }, eventPayload);
 ```
 
 <table width="100%">
@@ -170,44 +171,14 @@ webhooks.sign(secret, eventPayload);
   <tr>
     <td>
       <code>
-        eventPayload
+        algorithm
       </code>
       <em>
-        (Object)
+        (string)
       </em>
     </td>
     <td>
-      <strong>Required.</strong>
-      Webhook request payload as received from GitHub
-    </td>
-  </tr>
-</table>
-
-or
-
-```js
-webhooks.sign({
-  secret: <my_awesome_secret>,
-  algorithm: <"sha1" | "sha256">
-}, eventPayload);
-```
-
-<table width="100%">
-  <tr>
-    <td>
-      <code>
-        options
-      </code>
-      <em>
-        (Object)
-      </em>
-    </td>
-    <td>
-      <strong>Required.</strong> secret to generated the signature
-      algorithm: secret to generated the signature
-    </td>
-    <td>
-      algorithm to be applied when encrypting (sha1 by default)
+      Algorithm to calculate signature. Can be set to `sha1` or `sha256`. Defaults to `sha1`.
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -149,10 +149,67 @@ Returns the `webhooks` API.
 ### webhooks.sign()
 
 ```js
-webhooks.sign(eventPayload);
+webhooks.sign(secret, eventPayload);
 ```
 
 <table width="100%">
+  <tr>
+    <td>
+      <code>
+        secret
+      </code>
+      <em>
+        (string)
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong>
+      secret to generated the signature
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        eventPayload
+      </code>
+      <em>
+        (Object)
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong>
+      Webhook request payload as received from GitHub
+    </td>
+  </tr>
+</table>
+
+or
+
+```js
+webhooks.sign({
+  secret: <my_awesome_secret>,
+  algorithm: <"sha1" | "sha256">
+}, eventPayload);
+```
+
+<table width="100%">
+  <tr>
+    <td>
+      <code>
+        options
+      </code>
+      <em>
+        (Object)
+      </em>
+    </td>
+    <td>
+      <strong>Required.</strong> secret to generated the signature
+      algorithm: secret to generated the signature
+    </td>
+    <td>
+      algorithm to be applied when encrypting (sha1 by default)
+    </td>
+  </tr>
   <tr>
     <td>
       <code>

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -42,7 +42,8 @@ export function middleware(
   }
 
   const eventName = request.headers["x-github-event"] as WebhookEvents;
-  const signature = request.headers["x-hub-signature"] as string;
+  const signatureSHA1 = request.headers["x-hub-signature"] as string;
+  const signatureSHA256 = request.headers["x-hub-signature-256"] as string;
   const id = request.headers["x-github-delivery"] as string;
 
   debugWebhooks(`${eventName} event received (id: ${id})`);
@@ -62,7 +63,7 @@ export function middleware(
         id: id,
         name: eventName,
         payload,
-        signature,
+        signature: signatureSHA256 || signatureSHA1,
       });
     })
 

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -5,6 +5,7 @@ The `sign` method can be used as a standalone method.
 ```js
 const { sign } = require('@octokit/webhooks')
 const signature = sign(secret, eventPayload)
+const signature = sign({ secret, algorithm }, eventPayload)
 // string like "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8"
 ```
 
@@ -12,13 +13,26 @@ const signature = sign(secret, eventPayload)
   <tr>
     <td>
       <code>
-        options.secret
+        secret
       </code>
       <em>(String)</em>
     </td>
     <td>
       <strong>Required.</strong>
       Secret as configured in GitHub Settings.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        algorithm
+      </code>
+      <em>
+        (String)
+      </em>
+    </td>
+    <td>
+      Algorithm to calculate signature. Can be set to `sha1` or `sha256`. Defaults to `sha1`.
     </td>
   </tr>
   <tr>

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -14,16 +14,14 @@ export function sign(
   options: SignOptions | string,
   payload: string | object
 ): string {
-  let secret;
-  let algorithm;
+  const { secret, algorithm } =
+    typeof options === "string"
+      ? { secret: options, algorithm: Algorithm.SHA1 }
+      : {
+          secret: options.secret,
+          algorithm: options.algorithm || Algorithm.SHA1,
+        };
 
-  if (typeof options === "string") {
-    secret = options;
-    algorithm = Algorithm.SHA1;
-  } else {
-    secret = options.secret;
-    algorithm = options.algorithm || Algorithm.SHA1;
-  }
   // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {
     throw new TypeError("[@octokit/webhooks] secret & payload required");
@@ -31,7 +29,7 @@ export function sign(
 
   if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
     throw new TypeError(
-      "[@octokit/webhooks] algorithm should be 'sha1' or 'sha256'"
+      `[@octokit/webhooks] Algorithm ${algorithm} is not supported. Must be  'sha1' or 'sha256'`
     );
   }
 

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -7,7 +7,7 @@ export enum Algorithm {
 
 type SignOptions = {
   secret: string;
-  algorithm?: Algorithm;
+  algorithm?: string;
 };
 
 export function sign(
@@ -27,6 +27,10 @@ export function sign(
   // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {
     throw new TypeError("secret & payload required");
+  }
+
+  if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
+    throw new TypeError("algorithm should be 'sha1' or 'sha256'");
   }
 
   payload =

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,6 +1,29 @@
 import { createHmac } from "crypto";
 
-export function sign(secret: string, payload: string | object): string {
+export enum Algorithm {
+  SHA1 = "sha1",
+  SHA256 = "sha256",
+}
+
+type SignOptions = {
+  secret: string;
+  algorithm?: Algorithm;
+};
+
+export function sign(
+  options: SignOptions | string,
+  payload: string | object
+): string {
+  let secret;
+  let algorithm;
+
+  if (typeof options === "string") {
+    secret = options;
+    algorithm = Algorithm.SHA1;
+  } else {
+    secret = options.secret;
+    algorithm = options.algorithm ?? Algorithm.SHA1;
+  }
   // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {
     throw new TypeError("secret & payload required");
@@ -8,7 +31,9 @@ export function sign(secret: string, payload: string | object): string {
 
   payload =
     typeof payload === "string" ? payload : toNormalizedJsonString(payload);
-  return "sha1=" + createHmac("sha1", secret).update(payload).digest("hex");
+  return `${algorithm}=${createHmac(algorithm, secret)
+    .update(payload)
+    .digest("hex")}`;
 }
 
 function toNormalizedJsonString(payload: object) {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -26,11 +26,11 @@ export function sign(
   }
   // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {
-    throw new TypeError("secret & payload required");
+    throw new TypeError("[@octokit/webhooks] secret & payload required");
   }
 
   if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
-    throw new TypeError("algorithm should be 'sha1' or 'sha256'");
+    throw new TypeError("[@octokit/webhooks] algorithm should be 'sha1' or 'sha256'");
   }
 
   payload =

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -22,7 +22,7 @@ export function sign(
     algorithm = Algorithm.SHA1;
   } else {
     secret = options.secret;
-    algorithm = options.algorithm ?? Algorithm.SHA1;
+    algorithm = options.algorithm || Algorithm.SHA1;
   }
   // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -30,7 +30,9 @@ export function sign(
   }
 
   if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
-    throw new TypeError("[@octokit/webhooks] algorithm should be 'sha1' or 'sha256'");
+    throw new TypeError(
+      "[@octokit/webhooks] algorithm should be 'sha1' or 'sha256'"
+    );
   }
 
   payload =

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -3,7 +3,7 @@ import { Buffer } from "buffer";
 import { sign } from "../sign/index";
 
 const getAlgorithm = (signature: string) => {
-  return signature.startsWith("sha256=")? "sha256" : "sha1";
+  return signature.startsWith("sha256=") ? "sha256" : "sha1";
 };
 
 export function verify(

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -2,6 +2,10 @@ import { timingSafeEqual } from "crypto";
 import { Buffer } from "buffer";
 import { sign } from "../sign/index";
 
+const getAlgorithm = (signature: string) => {
+  return signature.indexOf("sha256=") === 0 ? "sha256" : "sha1";
+};
+
 export function verify(
   secret?: string,
   eventPayload?: object,
@@ -12,7 +16,10 @@ export function verify(
   }
 
   const signatureBuffer = Buffer.from(signature);
-  const verificationBuffer = Buffer.from(sign(secret, eventPayload));
+  const algorithm = getAlgorithm(signature);
+  const verificationBuffer = Buffer.from(
+    sign({ secret, algorithm }, eventPayload)
+  );
 
   if (signatureBuffer.length !== verificationBuffer.length) {
     return false;

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -3,7 +3,7 @@ import { Buffer } from "buffer";
 import { sign } from "../sign/index";
 
 const getAlgorithm = (signature: string) => {
-  return signature.indexOf("sha256=") === 0 ? "sha256" : "sha1";
+  return signature.startsWith("sha256=")? "sha256" : "sha1";
 };
 
 export function verify(

--- a/test/integration/server-test.ts
+++ b/test/integration/server-test.ts
@@ -73,7 +73,7 @@ describe("server-test", () => {
             headers: {
               "X-GitHub-Delivery": "123e4567-e89b-12d3-a456-426655440000",
               "X-GitHub-Event": "push",
-              "X-Hub-Signature": signatureSha1,
+              "X-Hub-Signature": "ignored",
               "X-Hub-Signature-256": signatureSha256,
             },
           }

--- a/test/integration/server-test.ts
+++ b/test/integration/server-test.ts
@@ -8,7 +8,7 @@ import pushEventPayload from "../fixtures/push-payload.json";
 
 const signatureSha1 = "sha1=f4d795e69b5d03c139cc6ea991ad3e5762d13e2f";
 const signatureSha256 =
-  "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
+  "sha256=2b49327af77d51c4c23700118b11d15c81d90c3bd57dafbbe32eb50085ce67e0";
 
 describe("server-test", () => {
   let availablePort: number;

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -1,4 +1,4 @@
-import { sign } from "../../src/sign";
+import { sign, Algorithm } from "../../src/sign";
 
 const eventPayload = {
   foo: "bar",
@@ -20,22 +20,70 @@ test("sign(secret) without eventPayload throws", () => {
   expect(() => sign.bind(null, secret)()).toThrow();
 });
 
-test("sign(secret, eventPayload) with eventPayload as object returns expected sha1 signature", () => {
-  const signature = sign(secret, eventPayload);
-  expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+describe("with eventPayload as object", () => {
+  describe("resturns expected sha1 signature", () => {
+    test("sign(secret, eventPayload)", () => {
+      const signature = sign(secret, eventPayload);
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
+
+    test("sign({secret}, eventPayload)", () => {
+      const signature = sign({ secret }, eventPayload);
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
+
+    test("sign({secret, sha1}, eventPayload)", () => {
+      const signature = sign(
+        { secret, algorithm: Algorithm.SHA1 },
+        eventPayload
+      );
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
+  });
+
+  describe("resturns expected sha256 signature", () => {
+    test("sign({secret, algorithm}, eventPayload)", () => {
+      const signature = sign(
+        { secret, algorithm: Algorithm.SHA256 },
+        eventPayload
+      );
+      expect(signature).toBe(
+        "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
+      );
+    });
+  });
 });
 
-test("sign(secret, eventPayload) with eventPayload as object returns expected sha256 signature", () => {
-  const signature = sign(secret, eventPayload);
-  expect(signature).toBe("sha256=kljsdfjkldasjfkaejkfwekuweur3298r2398r89fdsuf3");
-});
+describe("with eventPayload as string", () => {
+  describe("resturns expected sha1 signature", () => {
+    test("sign(secret, eventPayload)", () => {
+      const signature = sign(secret, JSON.stringify(eventPayload));
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
 
-test("sign(secret, eventPayload) with eventPayload as string returns expected sha1 signature", () => {
-  const signature = sign(secret, JSON.stringify(eventPayload));
-  expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
-});
+    test("sign({secret}, eventPayload)", () => {
+      const signature = sign({ secret }, JSON.stringify(eventPayload));
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
 
-test("sign(secret, eventPayload) with eventPayload as string returns expected sha256 signature", () => {
-  const signature = sign(secret, JSON.stringify(eventPayload));
-  expect(signature).toBe("sha256=kljsdfjkldasjfkaejkfwekuweur3298r2398r89fdsuf3");
+    test("sign({secret, sha1}, eventPayload)", () => {
+      const signature = sign(
+        { secret, algorithm: Algorithm.SHA1 },
+        JSON.stringify(eventPayload)
+      );
+      expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+    });
+  });
+
+  describe("resturns expected sha256 signature", () => {
+    test("sign({secret, algorithm}, eventPayload)", () => {
+      const signature = sign(
+        { secret, algorithm: Algorithm.SHA256 },
+        JSON.stringify(eventPayload)
+      );
+      expect(signature).toBe(
+        "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
+      );
+    });
+  });
 });

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -20,12 +20,22 @@ test("sign(secret) without eventPayload throws", () => {
   expect(() => sign.bind(null, secret)()).toThrow();
 });
 
-test("sign(secret, eventPayload) with eventPayload as object returns expected signature", () => {
+test("sign(secret, eventPayload) with eventPayload as object returns expected sha1 signature", () => {
   const signature = sign(secret, eventPayload);
   expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
 });
 
-test("sign(secret, eventPayload) with eventPayload as string returns expected signature", () => {
+test("sign(secret, eventPayload) with eventPayload as object returns expected sha256 signature", () => {
+  const signature = sign(secret, eventPayload);
+  expect(signature).toBe("sha256=kljsdfjkldasjfkaejkfwekuweur3298r2398r89fdsuf3");
+});
+
+test("sign(secret, eventPayload) with eventPayload as string returns expected sha1 signature", () => {
   const signature = sign(secret, JSON.stringify(eventPayload));
   expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
+});
+
+test("sign(secret, eventPayload) with eventPayload as string returns expected sha256 signature", () => {
+  const signature = sign(secret, JSON.stringify(eventPayload));
+  expect(signature).toBe("sha256=kljsdfjkldasjfkaejkfwekuweur3298r2398r89fdsuf3");
 });

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -1,4 +1,4 @@
-import { sign, Algorithm } from "../../src/sign";
+import { sign } from "../../src/sign";
 
 const eventPayload = {
   foo: "bar",
@@ -20,6 +20,13 @@ test("sign(secret) without eventPayload throws", () => {
   expect(() => sign.bind(null, secret)()).toThrow();
 });
 
+test("sign({secret, algorithm}) with an invalit algorithm throws", () => {
+  // @ts-ignore
+  expect(() =>
+    sign.bind(null, { secret, algorithm: "sha2" }, eventPayload)()
+  ).toThrow();
+});
+
 describe("with eventPayload as object", () => {
   describe("resturns expected sha1 signature", () => {
     test("sign(secret, eventPayload)", () => {
@@ -33,20 +40,14 @@ describe("with eventPayload as object", () => {
     });
 
     test("sign({secret, sha1}, eventPayload)", () => {
-      const signature = sign(
-        { secret, algorithm: Algorithm.SHA1 },
-        eventPayload
-      );
+      const signature = sign({ secret, algorithm: "sha1" }, eventPayload);
       expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
     });
   });
 
   describe("resturns expected sha256 signature", () => {
     test("sign({secret, algorithm}, eventPayload)", () => {
-      const signature = sign(
-        { secret, algorithm: Algorithm.SHA256 },
-        eventPayload
-      );
+      const signature = sign({ secret, algorithm: "sha256" }, eventPayload);
       expect(signature).toBe(
         "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
       );
@@ -68,7 +69,7 @@ describe("with eventPayload as string", () => {
 
     test("sign({secret, sha1}, eventPayload)", () => {
       const signature = sign(
-        { secret, algorithm: Algorithm.SHA1 },
+        { secret, algorithm: "sha1" },
         JSON.stringify(eventPayload)
       );
       expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
@@ -78,7 +79,7 @@ describe("with eventPayload as string", () => {
   describe("resturns expected sha256 signature", () => {
     test("sign({secret, algorithm}, eventPayload)", () => {
       const signature = sign(
-        { secret, algorithm: Algorithm.SHA256 },
+        { secret, algorithm: "sha256" },
         JSON.stringify(eventPayload)
       );
       expect(signature).toBe(

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -20,7 +20,7 @@ test("sign(secret) without eventPayload throws", () => {
   expect(() => sign.bind(null, secret)()).toThrow();
 });
 
-test("sign({secret, algorithm}) with an invalit algorithm throws", () => {
+test("sign({secret, algorithm}) with invalid algorithm throws", () => {
   // @ts-ignore
   expect(() =>
     sign.bind(null, { secret, algorithm: "sha2" }, eventPayload)()
@@ -39,7 +39,7 @@ describe("with eventPayload as object", () => {
       expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
     });
 
-    test("sign({secret, sha1}, eventPayload)", () => {
+    test("sign({secret, algorithm: 'sha1'}, eventPayload)", () => {
       const signature = sign({ secret, algorithm: "sha1" }, eventPayload);
       expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
     });
@@ -67,7 +67,7 @@ describe("with eventPayload as string", () => {
       expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
     });
 
-    test("sign({secret, sha1}, eventPayload)", () => {
+    test("sign({secret, algorithm: 'sha1'}, eventPayload)", () => {
       const signature = sign(
         { secret, algorithm: "sha1" },
         JSON.stringify(eventPayload)
@@ -76,8 +76,8 @@ describe("with eventPayload as string", () => {
     });
   });
 
-  describe("resturns expected sha256 signature", () => {
-    test("sign({secret, algorithm}, eventPayload)", () => {
+  describe("returns expected sha256 signature", () => {
+    test("sign({secret, algorithm: 'sha256'}, eventPayload)", () => {
       const signature = sign(
         { secret, algorithm: "sha256" },
         JSON.stringify(eventPayload)

--- a/test/integration/verify-test.ts
+++ b/test/integration/verify-test.ts
@@ -8,110 +8,104 @@ const signatureSHA1 = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
 const signatureSHA256 =
   "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
 
-describe("throws when calling", () => {
-  test("verify() without options", () => {
-    expect(() => verify()).toThrow();
-  });
-
-  test("verify(undefined, eventPayload) without secret", () => {
-    expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
-  });
-
-  test("verify(secret) without eventPayload", () => {
-    expect(() => verify.bind(null, secret)()).toThrow();
-  });
-
-  test("verify(secret, eventPayload) without options.signature", () => {
-    expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
-  });
+test("verify() without options", () => {
+  expect(() => verify()).toThrow();
 });
 
-describe("for SHA1 signature", () => {
-  test("verify(secret, eventPayload, signature) returns true for correct signature", () => {
-    const signatureMatches = verify(secret, eventPayload, signatureSHA1);
-    expect(signatureMatches).toBe(true);
-  });
-
-  test("verify(secret, eventPayload, signature) returns false for incorrect signature", () => {
-    const signatureMatches = verify(secret, eventPayload, "foo");
-    expect(signatureMatches).toBe(false);
-  });
-
-  test("verify(secret, eventPayload, signature) returns false for correct secret", () => {
-    const signatureMatches = verify("foo", eventPayload, signatureSHA1);
-    expect(signatureMatches).toBe(false);
-  });
-
-  test("verify(secret, eventPayload, signature) returns true if eventPayload contains (#71)", () => {
-    // https://github.com/octokit/webhooks.js/issues/71
-    const signatureMatchesLowerCaseSequence = verify(
-      "development",
-      {
-        foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-    );
-    expect(signatureMatchesLowerCaseSequence).toBe(true);
-    const signatureMatchesUpperCaseSequence = verify(
-      "development",
-      {
-        foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-    );
-    expect(signatureMatchesUpperCaseSequence).toBe(true);
-    const signatureMatchesEscapedSequence = verify(
-      "development",
-      {
-        foo: "\\u001b",
-      },
-      "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
-    );
-    expect(signatureMatchesEscapedSequence).toBe(true);
-  });
+test("verify(undefined, eventPayload) without secret", () => {
+  expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
 });
 
-describe("for SHA256 signature", () => {
-  test("verify(secret, eventPayload, signature) returns true for correct signature", () => {
-    const signatureMatches = verify(secret, eventPayload, signatureSHA256);
-    expect(signatureMatches).toBe(true);
-  });
+test("verify(secret) without eventPayload", () => {
+  expect(() => verify.bind(null, secret)()).toThrow();
+});
 
-  test("verify(secret, eventPayload, signature) returns false for incorrect signature", () => {
-    const signatureMatches = verify(secret, eventPayload, "foo");
-    expect(signatureMatches).toBe(false);
-  });
+test("verify(secret, eventPayload) without options.signature", () => {
+  expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
+});
 
-  test("verify(secret, eventPayload, signature) returns false for correct secret", () => {
-    const signatureMatches = verify("foo", eventPayload, signatureSHA256);
-    expect(signatureMatches).toBe(false);
-  });
+test("verify(secret, eventPayload, signatureSHA1) returns true for correct signature", () => {
+  const signatureMatches = verify(secret, eventPayload, signatureSHA1);
+  expect(signatureMatches).toBe(true);
+});
 
-  test("verify(secret, eventPayload, signature) returns true if eventPayload contains (#71)", () => {
-    // https://github.com/octokit/webhooks.js/issues/71
-    const signatureMatchesLowerCaseSequence = verify(
-      "development",
-      {
-        foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-    );
-    expect(signatureMatchesLowerCaseSequence).toBe(true);
-    const signatureMatchesUpperCaseSequence = verify(
-      "development",
-      {
-        foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-    );
-    expect(signatureMatchesUpperCaseSequence).toBe(true);
-    const signatureMatchesEscapedSequence = verify(
-      "development",
-      {
-        foo: "\\u001b",
-      },
-      "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
-    );
-    expect(signatureMatchesEscapedSequence).toBe(true);
-  });
+test("verify(secret, eventPayload, signatureSHA1) returns false for incorrect signature", () => {
+  const signatureMatches = verify(secret, eventPayload, "foo");
+  expect(signatureMatches).toBe(false);
+});
+
+test("verify(secret, eventPayload, signatureSHA1) returns false for correct secret", () => {
+  const signatureMatches = verify("foo", eventPayload, signatureSHA1);
+  expect(signatureMatches).toBe(false);
+});
+
+test("verify(secret, eventPayload, signatureSHA1) returns true if eventPayload contains (#71)", () => {
+  // https://github.com/octokit/webhooks.js/issues/71
+  const signatureMatchesLowerCaseSequence = verify(
+    "development",
+    {
+      foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
+    },
+    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+  );
+  expect(signatureMatchesLowerCaseSequence).toBe(true);
+  const signatureMatchesUpperCaseSequence = verify(
+    "development",
+    {
+      foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
+    },
+    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+  );
+  expect(signatureMatchesUpperCaseSequence).toBe(true);
+  const signatureMatchesEscapedSequence = verify(
+    "development",
+    {
+      foo: "\\u001b",
+    },
+    "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+  );
+  expect(signatureMatchesEscapedSequence).toBe(true);
+});
+
+test("verify(secret, eventPayload, signatureSHA256) returns true for correct signature", () => {
+  const signatureMatches = verify(secret, eventPayload, signatureSHA256);
+  expect(signatureMatches).toBe(true);
+});
+
+test("verify(secret, eventPayload, signatureSHA256) returns false for incorrect signature", () => {
+  const signatureMatches = verify(secret, eventPayload, "foo");
+  expect(signatureMatches).toBe(false);
+});
+
+test("verify(secret, eventPayload, signatureSHA256) returns false for correct secret", () => {
+  const signatureMatches = verify("foo", eventPayload, signatureSHA256);
+  expect(signatureMatches).toBe(false);
+});
+
+test("verify(secret, eventPayload, signatureSHA256) returns true if eventPayload contains (#71)", () => {
+  // https://github.com/octokit/webhooks.js/issues/71
+  const signatureMatchesLowerCaseSequence = verify(
+    "development",
+    {
+      foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
+    },
+    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+  );
+  expect(signatureMatchesLowerCaseSequence).toBe(true);
+  const signatureMatchesUpperCaseSequence = verify(
+    "development",
+    {
+      foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
+    },
+    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+  );
+  expect(signatureMatchesUpperCaseSequence).toBe(true);
+  const signatureMatchesEscapedSequence = verify(
+    "development",
+    {
+      foo: "\\u001b",
+    },
+    "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+  );
+  expect(signatureMatchesEscapedSequence).toBe(true);
 });

--- a/test/integration/verify-test.ts
+++ b/test/integration/verify-test.ts
@@ -4,63 +4,114 @@ const eventPayload = {
   foo: "bar",
 };
 const secret = "mysecret";
-const signature = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
+const signatureSHA1 = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
+const signatureSHA256 =
+  "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
 
-test("verify() without options throws", () => {
-  expect(() => verify()).toThrow();
+describe("throws when calling", () => {
+  test("verify() without options", () => {
+    expect(() => verify()).toThrow();
+  });
+
+  test("verify(undefined, eventPayload) without secret", () => {
+    expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
+  });
+
+  test("verify(secret) without eventPayload", () => {
+    expect(() => verify.bind(null, secret)()).toThrow();
+  });
+
+  test("verify(secret, eventPayload) without options.signature", () => {
+    expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
+  });
 });
 
-test("verify(undefined, eventPayload) without secret throws", () => {
-  expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
+describe("for SHA1 signature", () => {
+  test("verify(secret, eventPayload, signature) returns true for correct signature", () => {
+    const signatureMatches = verify(secret, eventPayload, signatureSHA1);
+    expect(signatureMatches).toBe(true);
+  });
+
+  test("verify(secret, eventPayload, signature) returns false for incorrect signature", () => {
+    const signatureMatches = verify(secret, eventPayload, "foo");
+    expect(signatureMatches).toBe(false);
+  });
+
+  test("verify(secret, eventPayload, signature) returns false for correct secret", () => {
+    const signatureMatches = verify("foo", eventPayload, signatureSHA1);
+    expect(signatureMatches).toBe(false);
+  });
+
+  test("verify(secret, eventPayload, signature) returns true if eventPayload contains (#71)", () => {
+    // https://github.com/octokit/webhooks.js/issues/71
+    const signatureMatchesLowerCaseSequence = verify(
+      "development",
+      {
+        foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
+      },
+      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    );
+    expect(signatureMatchesLowerCaseSequence).toBe(true);
+    const signatureMatchesUpperCaseSequence = verify(
+      "development",
+      {
+        foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
+      },
+      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    );
+    expect(signatureMatchesUpperCaseSequence).toBe(true);
+    const signatureMatchesEscapedSequence = verify(
+      "development",
+      {
+        foo: "\\u001b",
+      },
+      "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+    );
+    expect(signatureMatchesEscapedSequence).toBe(true);
+  });
 });
 
-test("verify(secret) without eventPayload throws", () => {
-  expect(() => verify.bind(null, secret)()).toThrow();
-});
+describe("for SHA256 signature", () => {
+  test("verify(secret, eventPayload, signature) returns true for correct signature", () => {
+    const signatureMatches = verify(secret, eventPayload, signatureSHA256);
+    expect(signatureMatches).toBe(true);
+  });
 
-test("verify(secret, eventPayload) without options.signature throws", () => {
-  expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
-});
+  test("verify(secret, eventPayload, signature) returns false for incorrect signature", () => {
+    const signatureMatches = verify(secret, eventPayload, "foo");
+    expect(signatureMatches).toBe(false);
+  });
 
-test("verify(secret, eventPayload, signature) returns true for correct signature", () => {
-  const signatureMatches = verify(secret, eventPayload, signature);
-  expect(signatureMatches).toBe(true);
-});
+  test("verify(secret, eventPayload, signature) returns false for correct secret", () => {
+    const signatureMatches = verify("foo", eventPayload, signatureSHA256);
+    expect(signatureMatches).toBe(false);
+  });
 
-test("verify(secret, eventPayload, signature) returns false for incorrect signature", () => {
-  const signatureMatches = verify(secret, eventPayload, "foo");
-  expect(signatureMatches).toBe(false);
-});
-
-test("verify(secret, eventPayload, signature) returns false for correct secret", () => {
-  const signatureMatches = verify("foo", eventPayload, signature);
-  expect(signatureMatches).toBe(false);
-});
-
-test("verify(secret, eventPayload, signature) returns true if eventPayload contains (#71)", () => {
-  // https://github.com/octokit/webhooks.js/issues/71
-  const signatureMatchesLowerCaseSequence = verify(
-    "development",
-    {
-      foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
-    },
-    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-  );
-  expect(signatureMatchesLowerCaseSequence).toBe(true);
-  const signatureMatchesUpperCaseSequence = verify(
-    "development",
-    {
-      foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
-    },
-    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
-  );
-  expect(signatureMatchesUpperCaseSequence).toBe(true);
-  const signatureMatchesEscapedSequence = verify(
-    "development",
-    {
-      foo: "\\u001b",
-    },
-    "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
-  );
-  expect(signatureMatchesEscapedSequence).toBe(true);
+  test("verify(secret, eventPayload, signature) returns true if eventPayload contains (#71)", () => {
+    // https://github.com/octokit/webhooks.js/issues/71
+    const signatureMatchesLowerCaseSequence = verify(
+      "development",
+      {
+        foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
+      },
+      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    );
+    expect(signatureMatchesLowerCaseSequence).toBe(true);
+    const signatureMatchesUpperCaseSequence = verify(
+      "development",
+      {
+        foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
+      },
+      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    );
+    expect(signatureMatchesUpperCaseSequence).toBe(true);
+    const signatureMatchesEscapedSequence = verify(
+      "development",
+      {
+        foo: "\\u001b",
+      },
+      "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+    );
+    expect(signatureMatchesEscapedSequence).toBe(true);
+  });
 });

--- a/test/integration/verify-test.ts
+++ b/test/integration/verify-test.ts
@@ -82,14 +82,14 @@ test("verify(secret, eventPayload, signatureSHA256) returns false for correct se
   expect(signatureMatches).toBe(false);
 });
 
-test("verify(secret, eventPayload, signatureSHA256) returns true if eventPayload contains (#71)", () => {
+test("verify(secret, eventPayload, signatureSHA256) returns true if eventPayload contains special characters (#71)", () => {
   // https://github.com/octokit/webhooks.js/issues/71
   const signatureMatchesLowerCaseSequence = verify(
     "development",
     {
       foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
     },
-    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    "sha256=afecc3caa27548bb90d51a50384cb2868b9a3327b4ad6a01c9bd4ed0f8b0b12c"
   );
   expect(signatureMatchesLowerCaseSequence).toBe(true);
   const signatureMatchesUpperCaseSequence = verify(
@@ -97,7 +97,7 @@ test("verify(secret, eventPayload, signatureSHA256) returns true if eventPayload
     {
       foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
     },
-    "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+    "sha256=afecc3caa27548bb90d51a50384cb2868b9a3327b4ad6a01c9bd4ed0f8b0b12c"
   );
   expect(signatureMatchesUpperCaseSequence).toBe(true);
   const signatureMatchesEscapedSequence = verify(
@@ -105,7 +105,7 @@ test("verify(secret, eventPayload, signatureSHA256) returns true if eventPayload
     {
       foo: "\\u001b",
     },
-    "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+    "sha256=6f8326efbacfbd04e870cea25b5652e635be8c9807f2fd5348ef60753c9e96ed"
   );
   expect(signatureMatchesEscapedSequence).toBe(true);
 });

--- a/test/integration/verify-test.ts
+++ b/test/integration/verify-test.ts
@@ -8,19 +8,19 @@ const signatureSHA1 = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
 const signatureSHA256 =
   "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
 
-test("verify() without options", () => {
+test("verify() without options throws", () => {
   expect(() => verify()).toThrow();
 });
 
-test("verify(undefined, eventPayload) without secret", () => {
+test("verify(undefined, eventPayload) without secret throws", () => {
   expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
 });
 
-test("verify(secret) without eventPayload", () => {
+test("verify(secret) without eventPayload throws", () => {
   expect(() => verify.bind(null, secret)()).toThrow();
 });
 
-test("verify(secret, eventPayload) without options.signature", () => {
+test("verify(secret, eventPayload) without options.signature throws", () => {
   expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
 });
 
@@ -39,7 +39,7 @@ test("verify(secret, eventPayload, signatureSHA1) returns false for correct secr
   expect(signatureMatches).toBe(false);
 });
 
-test("verify(secret, eventPayload, signatureSHA1) returns true if eventPayload contains (#71)", () => {
+test("verify(secret, eventPayload, signatureSHA1) returns true if eventPayload contains special characters (#71)", () => {
   // https://github.com/octokit/webhooks.js/issues/71
   const signatureMatchesLowerCaseSequence = verify(
     "development",

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -65,6 +65,7 @@ export default async function () {
     path: "/github-webhooks",
   });
 
+  sign("randomSecret", {});
   sign({ secret: "randomSecret" }, {});
   sign({ secret: "randomSecret", algorithm: "sha1" }, {});
   sign({ secret: "randomSecret", algorithm: "sha256" }, {});
@@ -151,5 +152,3 @@ export function webhookErrorTestDeprecated(error: WebhookError) {
   console.log(event);
   console.log(request);
 }
-
-sign("randomSecret", {});

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -65,7 +65,9 @@ export default async function () {
     path: "/github-webhooks",
   });
 
-  sign("randomSecret", {});
+  sign({ secret: "randomSecret" }, {});
+  sign({ secret: "randomSecret", algorithm: "sha1" }, {});
+  sign({ secret: "randomSecret", algorithm: "sha256" }, {});
 
   verify("randomSecret", {}, "randomSignature");
 
@@ -149,3 +151,5 @@ export function webhookErrorTestDeprecated(error: WebhookError) {
   console.log(event);
   console.log(request);
 }
+
+sign("randomSecret", {});


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
`sign()` supports 
* `sha256` signature
* keeps retrocompatibility with `sha1` signature
 
## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #320