### PR TITLE
ci(update): act on `octokit/webhooks release` dispatch event instead of waiting for dependabot

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,16 +1,15 @@
 name: Update
 on:
-  push:
-    branches:
-      - dependabot/npm_and_yarn/octokit/webhooks-definitions-*
+  repository_dispatch:
+    # https://github.com/apps/octokit-release-notifier
+    types: [octokit/webhooks release]
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: 12
       - run: npm ci
       - run: npm run update-known-events
       - run: npm run generate-types
@@ -20,7 +19,8 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           title: "\U0001F6A7 \U0001F916\U0001F4EF Webhooks changed"
-          body: "I found new changes in GitHub's GraphQL Schema \U0001F44B\U0001F916\n\nI can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
+          body: "A new release of [@octokit/webhooks](https://github.com/octokit/webhooks) was just released \U0001F44B\U0001F916\n\nThis pull request updates the TypeScript definitions derived from `@octokit/webhooks`. I can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
           branch: "${{ github.ref }}"
           author: Octokit Bot <octokitbot@martynus.net>
           commit-message: "WIP: Webhooks changed - please review"
+          labels: "maintenance"


### PR DESCRIPTION
addresses https://github.com/octokit/webhooks.js/pull/369\#pullrequestreview-544481033