### PR TITLE
fix(typescript): export `EventTypesPayload` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,10 @@ class Webhooks<T extends WebhookEvent = WebhookEvent, U = {}> {
 const createWebhooksApi = Webhooks.prototype.constructor;
 
 export { EventPayloads } from "./generated/event-payloads";
-export { WebhookEvents } from "./generated/get-webhook-payload-type-from-event";
+export {
+  EventTypesPayload,
+  WebhookEvents,
+} from "./generated/get-webhook-payload-type-from-event";
 
 export {
   createEventHandler,


### PR DESCRIPTION
This lets us use `EventTypesPayload` without having to import it the long way, i.e

```
import { WebhookEvents, Webhooks, sign, verify } from '@octokit/webhooks';
import { EventTypesPayload } from '@octokit/webhooks/dist-types/generated/get-webhook-payload-type-from-event';
```

I need this type in order to attempt to do narrowing via:

```
const isSpecificGithubEvent = <TName extends WebhookEvents>(
  event: EventTypesPayload[keyof EventTypesPayload],
  name: TName
): event is EventTypesPayload[TName] => event.name === name;
```

On an aside: `EventTypesPayload` isn't entirely correct as it's not the actual event payloads, which makes it harder to write a setup that narrows based on the event name; in general it'd be nice if there was a union type that let you narrow based on the `name` :/