### PR TITLE
fix(typescript): mark `verify` parameters as required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { WebhookEvents } from "./generated/get-webhook-payload-type-from-event";
 // U holds the return value of `transform` function in Options
 class Webhooks<T extends WebhookEvent = WebhookEvent, U = {}> {
   public sign: (payload: string | object) => string;
-  public verify: (eventPayload?: object, signature?: string) => boolean;
+  public verify: (eventPayload: object, signature: string) => boolean;
   public on: <E extends WebhookEvents>(
     event: E | E[],
     callback: HandlerFunction<E, U>

--- a/src/middleware/verify-and-receive.ts
+++ b/src/middleware/verify-and-receive.ts
@@ -5,7 +5,12 @@ export function verifyAndReceive(
   state: State,
   event: WebhookEvent & { signature: string }
 ): any {
-  const matchesSignature = verify(state.secret, event.payload, event.signature);
+  // verify will validate that the secret is not undefined
+  const matchesSignature = verify(
+    state.secret!,
+    event.payload,
+    event.signature
+  );
 
   if (!matchesSignature) {
     const error = new Error(

--- a/src/verify/README.md
+++ b/src/verify/README.md
@@ -4,7 +4,7 @@ The `verify` method can be used as a standalone method.
 
 ```js
 const { verify } = require('@octokit/webhooks')
-const matchesSignature = verify(secret, eventData, signature)
+const matchesSignature = verify(secret, eventPayload, signature)
 // true or false
 ```
 
@@ -12,7 +12,7 @@ const matchesSignature = verify(secret, eventData, signature)
   <tr>
     <td>
       <code>
-        options.secret
+        secret
       </code>
       <em>(String)</em>
     </td>
@@ -51,6 +51,6 @@ const matchesSignature = verify(secret, eventData, signature)
   </tr>
 </table>
 
-Returns `true` or `false`. Throws error if `secret, ``eventPayload` or `signature` not passed.
+Returns `true` or `false`. Throws error if `secret`, `eventPayload` or `signature` not passed.
 
 Back to [@octokit/webhooks README](..).

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -7,9 +7,9 @@ const getAlgorithm = (signature: string) => {
 };
 
 export function verify(
-  secret?: string,
-  eventPayload?: object,
-  signature?: string
+  secret: string,
+  eventPayload: object,
+  signature: string
 ): boolean {
   if (!secret || !eventPayload || !signature) {
     throw new TypeError(

--- a/test/integration/verify-test.ts
+++ b/test/integration/verify-test.ts
@@ -9,18 +9,22 @@ const signatureSHA256 =
   "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
 
 test("verify() without options throws", () => {
+  // @ts-expect-error
   expect(() => verify()).toThrow();
 });
 
 test("verify(undefined, eventPayload) without secret throws", () => {
+  // @ts-expect-error
   expect(() => verify.bind(null, undefined, eventPayload)()).toThrow();
 });
 
 test("verify(secret) without eventPayload throws", () => {
+  // @ts-expect-error
   expect(() => verify.bind(null, secret)()).toThrow();
 });
 
 test("verify(secret, eventPayload) without options.signature throws", () => {
+  // @ts-expect-error
   expect(() => verify.bind(null, secret, eventPayload)()).toThrow();
 });
 


### PR DESCRIPTION
The parameters for `verify` are not optional - this matches the pattern used for `sign`.