### PR TITLE
refactor(typescript): use `ts-expect-error` instead of `ts-ignore`

### DIFF
--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -20,8 +20,7 @@ function getHooks(
   hooks.push(state.hooks[eventName]);
   hooks.push(state.hooks["*"]);
 
-  // @ts-ignore
-  return [].concat(...hooks.filter(Boolean));
+  return ([] as Function[]).concat(...hooks.filter(Boolean));
 }
 
 // main handler function

--- a/src/middleware/get-payload.ts
+++ b/src/middleware/get-payload.ts
@@ -10,7 +10,7 @@ export function getPayload(
   // If request.body already exists we can stop here
   // See https://github.com/octokit/webhooks.js/pull/23
 
-  // @ts-ignore
+  // @ts-expect-error
   if (request.body) return Promise.resolve(request.body);
 
   return new Promise((resolve, reject) => {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -22,7 +22,6 @@ export function sign(
           algorithm: options.algorithm || Algorithm.SHA1,
         };
 
-  // @ts-ignore throw friendly error message when required options are missing
   if (!secret || !payload) {
     throw new TypeError("[@octokit/webhooks] secret & payload required");
   }

--- a/test/integration/server-test.ts
+++ b/test/integration/server-test.ts
@@ -182,7 +182,7 @@ describe("server-test", () => {
     const server = http.createServer((req, res) => {
       req.once("data", (chunk) => dataChunks.push(chunk));
       req.once("end", () => {
-        // @ts-ignore
+        // @ts-expect-error
         req.body = JSON.parse(Buffer.concat(dataChunks).toString());
         api.middleware(req, res);
 

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -6,22 +6,21 @@ const eventPayload = {
 const secret = "mysecret";
 
 test("sign() without options throws", () => {
-  // @ts-ignore
+  // @ts-expect-error
   expect(() => sign()).toThrow();
 });
 
 test("sign(undefined, eventPayload) without secret throws", () => {
-  // @ts-ignore
+  // @ts-expect-error
   expect(() => sign.bind(null, undefined, eventPayload)()).toThrow();
 });
 
 test("sign(secret) without eventPayload throws", () => {
-  // @ts-ignore
+  // @ts-expect-error
   expect(() => sign.bind(null, secret)()).toThrow();
 });
 
 test("sign({secret, algorithm}) with invalid algorithm throws", () => {
-  // @ts-ignore
   expect(() =>
     sign.bind(null, { secret, algorithm: "sha2" }, eventPayload)()
   ).toThrow();

--- a/test/unit/event-handler-on-test.ts
+++ b/test/unit/event-handler-on-test.ts
@@ -11,7 +11,7 @@ const state: State = {
 // Test broken with TypeScript without the ignore
 test("receiver.on with invalid event name", () => {
   simple.mock(console, "warn").callFn(function () {});
-  // @ts-ignore
+  // @ts-expect-error
   receiverOn(state, "foo", noop);
   expect((console.warn as simple.Stub<void>).callCount).toBe(1);
   expect((console.warn as simple.Stub<void>).lastCall.arg).toBe(

--- a/test/unit/event-handler-receive-test.ts
+++ b/test/unit/event-handler-receive-test.ts
@@ -7,20 +7,20 @@ const state: State = {
 };
 
 test("options: none", () => {
-  // @ts-ignore
+  // @ts-expect-error
   expect(() => receive(state)).toThrow();
 });
 
 test("options: name", () => {
   expect(() => {
-    // @ts-ignore
+    // @ts-expect-error
     receive(state, { name: "foo" });
   }).toThrow();
 });
 
 test("options: name, payload", () => {
   expect(() => {
-    // @ts-ignore
+    // @ts-expect-error
     receive(state, { name: "foo", payload: {} });
   }).not.toThrow();
 });


### PR DESCRIPTION
Replaces uses of `ts-ignore` with `ts-expect-error` - these are better as they effectively invert typescripts behaviour so that it errors if there *isn't* an error (unlike `ts-ignore` which just causes errors to be ignored regardless of if there are actually errors).

This revealed a couple of `ts-ignore`s that are not needed 🎉 