### PR TITLE
chore: update `ts-jest` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     },
     "globals": {
       "ts-jest": {
-        "tsConfig": {
+        "tsconfig": {
           "esModuleInterop": true
         }
       }


### PR DESCRIPTION
Addresses this warning in CI:

> ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
