### PR TITLE
feat(typescript): type `algorithm` property for `sign` options

### DIFF
--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -7,7 +7,7 @@ export enum Algorithm {
 
 type SignOptions = {
   secret: string;
-  algorithm?: string;
+  algorithm?: Algorithm | "sha1" | "sha256";
 };
 
 export function sign(

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -22,7 +22,7 @@ test("sign(secret) without eventPayload throws", () => {
 
 test("sign({secret, algorithm}) with invalid algorithm throws", () => {
   expect(() =>
-    sign.bind(null, { secret, algorithm: "sha2" }, eventPayload)()
+    sign.bind(null, { secret, algorithm: "sha2" as "sha1" }, eventPayload)()
   ).toThrow();
 });
 


### PR DESCRIPTION
I've done it like this because if you do just `Algorithm` TS won't let you pass it in as just a string - you'll have to always use the `Algorithm` enum.

While this isn't a bad thing (since the enum is exported), it'd be a change for TS users - this way you can pass both the enum and plain strings without being able to pass just any old string.

Another way around this would be to make `Algorithm` a `const` enum, but then that'd break people who are currently importing and using the enum since it would no longer exist at runtime.

These changes could be made later down the line if desired, such as if a major release is done.