### PR TITLE
fix(typescript): `eventPayload` parameter for `verify()` can be `string`

### DIFF
--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -8,7 +8,7 @@ const getAlgorithm = (signature: string) => {
 
 export function verify(
   secret: string,
-  eventPayload: object,
+  eventPayload: string | object,
   signature: string
 ): boolean {
   if (!secret || !eventPayload || !signature) {


### PR DESCRIPTION
As per [this comment](https://github.com/octokit/webhooks.js/pull/372#issuecomment-739539034), `eventPayload` can be either a string or an object, but currently it only accepts an `object` type.