### PR TITLE
Add failing test to verify that "request.setEncoding("utf8")" is needed

### DIFF
--- a/test/integration/middleware-test.ts
+++ b/test/integration/middleware-test.ts
@@ -11,6 +11,7 @@ type RequestMock = EventEmitter & {
   method: RequestMethodType;
   headers: { [key: string]: string };
   url: string;
+  setEncoding: jest.Mock<void, string[]>;
 };
 
 const headers = {
@@ -24,7 +25,7 @@ test("Invalid payload", (done) => {
     method: RequestMethodType.POST,
     headers,
     url: "/",
-    setEncoding: function () {},
+    setEncoding: jest.fn(),
   });
 
   const responseMock = {
@@ -38,12 +39,13 @@ test("Invalid payload", (done) => {
     expect(responseMock.end).toHaveBeenCalledWith(
       expect.stringContaining("SyntaxError: Invalid JSON")
     );
+    expect(requestMock.setEncoding).toHaveBeenCalledWith("utf8");
     done();
   });
 
   requestMock.emit("data", Buffer.from("foo"));
   requestMock.emit("end");
-  expect.assertions(2);
+  expect.assertions(3);
 });
 
 test("request error", (done) => {
@@ -51,7 +53,7 @@ test("request error", (done) => {
     method: RequestMethodType.POST,
     headers,
     url: "/",
-    setEncoding: function () {},
+    setEncoding: jest.fn(),
   });
 
   const responseMock = {
@@ -65,10 +67,11 @@ test("request error", (done) => {
     expect(responseMock.end).toHaveBeenCalledWith(
       expect.stringContaining("Error: oops")
     );
+    expect(requestMock.setEncoding).toHaveBeenCalledWith("utf8");
     done();
   });
 
   const error = new Error("oops");
   requestMock.emit("error", error);
-  expect.assertions(2);
+  expect.assertions(3);
 });

--- a/test/integration/middleware-test.ts
+++ b/test/integration/middleware-test.ts
@@ -20,7 +20,7 @@ const headers = {
   "x-hub-signature": "sha1=f4d795e69b5d03c139cc6ea991ad3e5762d13e2f",
 };
 
-test("Invalid payload", (done) => {
+test("Invalid payload", () => {
   const requestMock: RequestMock = Object.assign(new EventEmitter(), {
     method: RequestMethodType.POST,
     headers,
@@ -34,21 +34,21 @@ test("Invalid payload", (done) => {
   };
 
   const middleware = createMiddleware({ secret: "mysecret" });
-  middleware(requestMock, responseMock).then(() => {
+  const middlewareDone = middleware(requestMock, responseMock).then(() => {
     expect(responseMock.statusCode).toBe(400);
     expect(responseMock.end).toHaveBeenCalledWith(
       expect.stringContaining("SyntaxError: Invalid JSON")
     );
     expect(requestMock.setEncoding).toHaveBeenCalledWith("utf8");
-    done();
   });
 
   requestMock.emit("data", Buffer.from("foo"));
   requestMock.emit("end");
-  expect.assertions(3);
+
+  return middlewareDone;
 });
 
-test("request error", (done) => {
+test("request error", () => {
   const requestMock: RequestMock = Object.assign(new EventEmitter(), {
     method: RequestMethodType.POST,
     headers,
@@ -62,16 +62,15 @@ test("request error", (done) => {
   };
 
   const middleware = createMiddleware({ secret: "mysecret" });
-  middleware(requestMock, responseMock).then(() => {
+  const middlewareDone = middleware(requestMock, responseMock).then(() => {
     expect(responseMock.statusCode).toBe(500);
     expect(responseMock.end).toHaveBeenCalledWith(
       expect.stringContaining("Error: oops")
     );
     expect(requestMock.setEncoding).toHaveBeenCalledWith("utf8");
-    done();
   });
 
   const error = new Error("oops");
   requestMock.emit("error", error);
-  expect.assertions(3);
+  return middlewareDone;
 });


### PR DESCRIPTION
Hey @gr2m 👋 

This adds assertions to the `tests/integration/middleware-test.ts` test cases to make sure that `request.setEncoding('utf8')` is called when the `getPayload` middleware is called. This modifies the RequestMock to use a jest mock for setEncoding.

I also changed the test cases in that file to use the Jest functionality where the test case returns a promise that the test runner will wait to resolve before considering the test case to be done, instead of using the `done` callback method. With the promise approach, the assertions in the middleware's then handler are guaranteed to be called before the test considers itself done, so I believe we can remove the `expect.assertions` call. Also if for some reason the promise returned by the middleware rejects, Jest will be able to handle the rejection instead of it being caught globally. I made that in a separate commit though, so if the refactoring is a little too much I can remove that from the PR too.

Here's an example of the failing tests when `setEncoding` is not called

![image](https://user-images.githubusercontent.com/2539016/103378902-c2e1e280-4a98-11eb-8072-6f7d13fcac4a.png)

Fixes #203 