### PR TITLE
chore: add `prettier-plugin-packagejson` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest": "^26.2.2",
     "pascal-case": "^3.0.0",
     "prettier": "^2.0.1",
+    "prettier-plugin-packagejson": "^2.2.9",
     "semantic-release": "^17.0.0",
     "table-builder": "^2.1.1",
     "ts-jest": "^26.2.0",


### PR DESCRIPTION
Somehow I managed to add this to the lock, but not actually list it as a dev dependency when doing #412 🤔 