### PR TITLE
chore: move `jest` config into `jest.config.ts`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,25 @@
+import { Config } from "@jest/types";
+import "ts-jest";
+
+const config: Config.InitialOptions = {
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        esModuleInterop: true,
+      },
+    },
+  },
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testRegex: /test\/.*\/.*.test.ts/u.source,
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2511,6 +2511,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3778,6 +3784,12 @@
         "parse-json": "^4.0.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4022,6 +4034,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -14510,6 +14528,20 @@
         }
       }
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -15157,6 +15189,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,27 +21,6 @@
     "validate:ts": "tsc --noEmit --noImplicitAny --target es2020 --esModuleInterop --moduleResolution node test/typescript-validate.ts"
   },
   "prettier": {},
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "statements": 100,
-        "branches": 100,
-        "functions": 100,
-        "lines": 100
-      }
-    },
-    "globals": {
-      "ts-jest": {
-        "tsconfig": {
-          "esModuleInterop": true
-        }
-      }
-    },
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "testMatch": null,
-    "testRegex": "test/.*/.*.ts"
-  },
   "dependencies": {
     "@octokit/request-error": "^2.0.2",
     "aggregate-error": "^3.1.0",
@@ -49,6 +28,7 @@
   },
   "devDependencies": {
     "@gimenete/type-writer": "^0.1.5",
+    "@jest/types": "^26.6.2",
     "@octokit/tsconfig": "^1.0.1",
     "@octokit/webhooks-definitions": "^3.22.2",
     "@pika/pack": "^0.5.0",
@@ -67,6 +47,7 @@
     "semantic-release": "^17.0.0",
     "table-builder": "^2.1.1",
     "ts-jest": "^26.2.0",
+    "ts-node": "^9.1.1",
     "typescript": "^4.0.2"
   },
   "publishConfig": {


### PR DESCRIPTION
Using `jest.config.ts` gives us a few advantages:

  * strict config checking, which shows up in your editor rather than having to run `jest`
  * reduces the size of published package a bit, since the config is no longer in the `package.json`
  * lets us use javascript features that make things safer/easier/clearer etc (i.e `/.../u.source` for regexps)