### PR TITLE
fix: type the return of `createEventHandler`

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -1,3 +1,12 @@
+import type {
+  EmitterAnyEvent,
+  EmitterEventName,
+  EmitterWebhookEvent,
+  HandlerFunction,
+  Options,
+  State,
+  WebhookEventHandlerError,
+} from "../types";
 import {
   receiverOn as on,
   receiverOnAny as onAny,
@@ -5,9 +14,22 @@ import {
 } from "./on";
 import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
-import { Options, State } from "../types";
 
-export function createEventHandler(options: Options<any>) {
+interface EventHandler<TTransformed = unknown> {
+  on<E extends EmitterEventName>(
+    event: E | E[],
+    callback: HandlerFunction<E, TTransformed>
+  ): void;
+  onAny(handler: (event: EmitterAnyEvent) => any): void;
+  onError(handler: (event: WebhookEventHandlerError) => any): void;
+  removeListener<E extends EmitterEventName>(
+    event: E | E[],
+    callback: HandlerFunction<E, TTransformed>
+  ): void;
+  receive(event: EmitterWebhookEvent): Promise<void>;
+}
+
+export function createEventHandler(options: Options<any>): EventHandler {
   const state: State = {
     hooks: {},
   };


### PR DESCRIPTION
This fixes the error that occurs when building the project currently, caused by merging #406 

> Error: src/event-handler/index.ts(10,17): error TS4058: Return type of exported function has or is using name 'BaseWebhookEvent' from external module "/home/runner/work/webhooks.js/webhooks.js/src/types" but cannot be named.

This occurs because `createEventHandler` doesn't have an explicit return type but is exported meaning TypeScript has to infer the return for the declaration file. For efficiently when doing this TypeScript inlines types as much as possible leading to the above error because it infers the type of the `onAny` property of the return to be `handler: (event: import("../types").BaseWebhookEvent<"*">) => any) => void`, which errors since `BaseWebhookEvent` is not exported.

This actually revealed it's also doing this for `EmitterEventName`, meaning the declaration file for `createEventHandler` has an inline string union of ~200 strings *four times* (because we're doing  `EmitterEventName | EmitterEventName[]` so it's doing ` "push" | "error" | "public" | "label" | "meta" | ... | ( "push" | "error" | "public" | "label" | "meta" | ...)[]`).

So I've explicitly defined the return type for `createEventEmitter` - this type ideally should be propertaged to the rest of the project (i.e `State#eventEmitter` should be using this type), but it's not an easy thing to apply for a few reasons, so will leave that for a follow-up PR down the line (tbh would be good if we could remove/reduce `State` as much as possible, as it's a complex object)