### PR TITLE
refactor(webhooks-class): rename variables in Webhooks generic class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,10 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<E extends EmitterWebhookEvent = EmitterWebhookEvent, TTransformed = unknown> {
+class Webhooks<
+  E extends EmitterWebhookEvent = EmitterWebhookEvent,
+  TTransformed = unknown
+> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterEventName>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,18 +21,18 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<T extends EmitterWebhookEvent = EmitterWebhookEvent, U = {}> {
+class Webhooks<E extends EmitterWebhookEvent = EmitterWebhookEvent, TTransformed = unknown> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, U>
+    callback: HandlerFunction<E, TTransformed>
   ) => void;
   public onAny: (callback: (event: EmitterAnyEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
   public removeListener: <E extends EmitterEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, U>
+    callback: HandlerFunction<E, TTransformed>
   ) => void;
   public receive: (options: {
     id: string;
@@ -48,7 +48,7 @@ class Webhooks<T extends EmitterWebhookEvent = EmitterWebhookEvent, U = {}> {
     options: EmitterWebhookEventMap[WebhookEventName] & { signature: string }
   ) => Promise<void>;
 
-  constructor(options?: Options<T>) {
+  constructor(options?: Options<E>) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Rename variables in Webhooks generic class

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For consistency with https://github.com/octokit/webhooks.js/blob/28f6a426adb68de570544dbf7c2db5e09a115b6c/src/event-handler/index.ts#L18

Fix #424