### PR TITLE
fix(types): accept string event.name for receive()

### DIFF
--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -26,8 +26,8 @@ function getHooks(
 export function receiverHandle(
   state: State,
   event: {
-    id: string | undefined;
-    name: string | undefined;
+    id: string;
+    name: string;
     payload: unknown;
   }
 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,11 @@ class Webhooks<
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ) => void;
-  public receive: (event: EmitterWebhookEvent) => Promise<void>;
+  public receive: (options: {
+    id: string | undefined;
+    name: string | undefined;
+    payload: unknown;
+  }) => Promise<void>;
   public middleware: (
     request: IncomingMessage,
     response: ServerResponse,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,8 @@ class Webhooks<
     callback: HandlerFunction<E, TTransformed>
   ) => void;
   public receive: (options: {
-    id: string | undefined;
-    name: string | undefined;
+    id: string;
+    name: string;
     payload: unknown;
   }) => Promise<void>;
   public middleware: (


### PR DESCRIPTION
Since #428 I get the following type error:
```TypeScript
webhooks.receive({
  id: request.headers["x-github-delivery"],
  name: request.headers["x-github-event"],
  ^^^^ TS2322: Type 'string' is not assignable to type '"status" | "delete" | "package" | "installation" | "repository" | "team" | "member" | "project" | "public" | "push" | "deployment" | "label" | "milestone" | "release" | "organization" | ... 187 more ... | "workflow_run.requested"'.
  payload: request.body,
});
```

Instead of changing `webhooks.receive()` to match `eventHandler.receive()` (as in #428), can we do the reverse and change `eventHandler.receive()` to match `webhooks.receive()` (as in this PR)?

I additionally added `| undefined` because:
1. It's checked in `.receive()` https://github.com/octokit/webhooks.js/blob/b7991135bbc10e759320094353946127f04d2079/src/event-handler/receive.ts#L46-L48
2. It avoids having to either non-null assert `request.headers["x-github-event"]!` or test it before calling `.receive()` (redundant since it's checked again by `.receive()`) when running with `--noUncheckedIndexedAccess`