### PR TITLE
fix(typescript): resolve correct value for `BaseWebhookEvent#name`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,17 @@ export type EmitterEvent = EmitterEventMap[EmitterEventName];
 
 export type EmitterAnyEvent = EmitterWebhookEventMap["*"];
 
+export type ToWebhookEvent<
+  TEmitterEvent extends string
+> = TEmitterEvent extends `${infer TWebhookEvent}.${string}`
+  ? TWebhookEvent
+  : TEmitterEvent;
+
 interface BaseWebhookEvent<
   TName extends keyof EmitterEventPayloadMap = keyof EmitterEventPayloadMap
 > {
   id: string;
-  name: TName;
+  name: ToWebhookEvent<TName>;
   payload: EmitterEventPayloadMap[TName];
 }
 

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -26,8 +26,10 @@ const fn = (webhookEvent: EmitterWebhookEvent) => {
       console.log(webhookEvent.payload.sender);
     }
   }
+  // @ts-expect-error TS2367:
+  //  This condition will always return 'false' since the types '"*" | "check_run" | ... many more ... | "workflow_run"' and '"check_run.completed"' have no overlap.
   if (webhookEvent.name === "check_run.completed") {
-    console.log(webhookEvent.payload.action);
+    //
   }
 
   if (webhookEvent.name === "*") {
@@ -167,6 +169,28 @@ export default async function () {
       console.log(payload.label.name);
     } else {
       console.log(payload.comment.body);
+    }
+  });
+
+  webhooks.on(["check_run.completed", "code_scanning_alert.fixed"], (event) => {
+    if (event.name === "check_run") {
+      console.log(`a run was ${event.payload.action}!`);
+
+      if (event.payload.action === "completed") {
+        console.log("it was the completed action, obviously!");
+      }
+
+      // @ts-expect-error TS2367:
+      //  This condition will always return 'false' since the types '"completed"' and '"created"' have no overlap.
+      if (event.payload.action === "created") {
+        //
+      }
+    }
+
+    // @ts-expect-error TS2367:
+    //  This condition will always return 'false' since the types '"check_run" | "code_scanning_alert"' and '"repository"' have no overlap.
+    if (event.name === "repository") {
+      //
     }
   });
 


### PR DESCRIPTION
This was actually a lot easier than I expected, but it makes total sense in hindsight.

This does put our minimal TypeScript version at 4.1 or higher - personally I don't have a problem with this, especially since we consider TypeScript changes to be non-breaking, but worth mentioning.

Fixes #431 