### PR TITLE
fix(deps): move `@octokit/webhooks-definitions` to non-dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,8 +1832,7 @@
     "@octokit/webhooks-definitions": {
       "version": "3.57.2",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.57.2.tgz",
-      "integrity": "sha512-SsYwG5ujYfNkhkaiw4OryIHtCilRBiXug2wM4Obl4aoyd9f02k2ohioWjVC99Pe21ZAzfiy26cd9yM6viS5cvQ==",
-      "dev": true
+      "integrity": "sha512-SsYwG5ujYfNkhkaiw4OryIHtCilRBiXug2wM4Obl4aoyd9f02k2ohioWjVC99Pe21ZAzfiy26cd9yM6viS5cvQ=="
     },
     "@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "prettier": {},
   "dependencies": {
     "@octokit/request-error": "^2.0.2",
+    "@octokit/webhooks-definitions": "3.57.2",
     "aggregate-error": "^3.1.0",
     "debug": "^4.0.0"
   },
   "devDependencies": {
     "@jest/types": "^26.6.2",
     "@octokit/tsconfig": "^1.0.1",
-    "@octokit/webhooks-definitions": "3.57.2",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-node": "^0.9.2",
     "@pika/plugin-ts-standard-pkg": "^0.9.2",


### PR DESCRIPTION
Ref: https://github.com/octokit/webhooks.js/issues/436#issuecomment-772933113