### PR TITLE
🚧  fix(typescript): remove `new Webhooks` type arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ class Webhooks<
     options: EmitterWebhookEventMap[WebhookEventName] & { signature: string }
   ) => Promise<void>;
 
-  constructor(options?: Options<E>) {
+  constructor(options?: Options<E, TTransformed>) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,10 +37,10 @@ interface BaseWebhookEvent<
   payload: EmitterEventPayloadMap[TName];
 }
 
-export interface Options<T extends EmitterWebhookEvent> {
+export interface Options<T extends EmitterWebhookEvent, TTransformed> {
   path?: string;
   secret?: string;
-  transform?: TransformMethod<T>;
+  transform?: TransformMethod<T, TTransformed>;
 }
 
 type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
@@ -65,7 +65,8 @@ type Hooks = {
   [key: string]: Function[];
 };
 
-export interface State extends Options<any> {
+export interface State<TTransformed = unknown>
+  extends Options<any, TTransformed> {
   eventHandler?: any;
   hooks: Hooks;
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -91,7 +91,7 @@ export default async function () {
   });
 
   // Check all supported options
-  const webhooks = new Webhooks<EmitterWebhookEvent, { foo: string }>({
+  const webhooks = new Webhooks({
     secret: "bleh",
     path: "/webhooks",
     transform: (event) => {


### PR DESCRIPTION
This is a follow up to https://github.com/octokit/webhooks.js/pull/292#discussion_r499795073

I really do not like that we introduced this type argument as I think there should be a way to infer it from the `transform` option if present. 

This should also address 

> it looks like the types think that octokit is no longer a property on the context passed into a webhook:

from https://github.com/octokit/webhooks.js/issues/436#issuecomment-772934380

In a nutshell, this should work

```ts
const webhooks = new Webhooks({
  secret: "bleh",
  transform: (event) => {
    return {...event, foo: "bar" };
  },
});
webhooks.on("issues", (event) => {
  // event.foo is typed as "string"
  console.log(event.foo);
});
```

Anyone up for looking into this?