### PR TITLE
fix(types): .onAny() event.name

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -1,5 +1,4 @@
 import type {
-  EmitterAnyEvent,
   EmitterEventName,
   EmitterWebhookEvent,
   HandlerFunction,
@@ -20,7 +19,7 @@ interface EventHandler<TTransformed = unknown> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ): void;
-  onAny(handler: (event: EmitterAnyEvent) => any): void;
+  onAny(handler: (event: EmitterWebhookEvent) => any): void;
   onError(handler: (event: WebhookEventHandlerError) => any): void;
   removeListener<E extends EmitterEventName>(
     event: E | E[],

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,6 +1,6 @@
 import { emitterEventNames } from "../generated/webhook-names";
 import {
-  EmitterAnyEvent,
+  EmitterWebhookEvent,
   EmitterEventName,
   State,
   WebhookEventHandlerError,
@@ -49,7 +49,7 @@ export function receiverOn(
 
 export function receiverOnAny(
   state: State,
-  handler: (event: EmitterAnyEvent) => any
+  handler: (event: EmitterWebhookEvent) => any
 ) {
   handleEventHandlers(state, "*", handler);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from "./middleware/verify-and-receive";
 import { sign } from "./sign/index";
 import {
-  EmitterAnyEvent,
   EmitterEventName,
   EmitterWebhookEvent,
   EmitterWebhookEventMap,
@@ -31,7 +30,7 @@ class Webhooks<
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ) => void;
-  public onAny: (callback: (event: EmitterAnyEvent) => any) => void;
+  public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
   public removeListener: <E extends EmitterEventName>(
     event: E | E[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,6 @@ export type EmitterEventMap = EmitterWebhookEventMap & {
 export type EmitterEventName = keyof EmitterEventMap;
 export type EmitterEvent = EmitterEventMap[EmitterEventName];
 
-export type EmitterAnyEvent = EmitterWebhookEventMap["*"];
-
 export type ToWebhookEvent<
   TEmitterEvent extends string
 > = TEmitterEvent extends `${infer TWebhookEvent}.${string}`


### PR DESCRIPTION
Like #435, the `.onAny()` `event.name` is e.g. "check_run", vs. "*"
https://github.com/octokit/webhooks.js/blob/aaec66e85d8e33cd5352152ed715af652be25d9d/test/integration/event-handler-test.ts#L30
https://github.com/octokit/webhooks.js/blob/aaec66e85d8e33cd5352152ed715af652be25d9d/test/integration/event-handler-test.ts#L65
https://github.com/octokit/webhooks.js/blob/aaec66e85d8e33cd5352152ed715af652be25d9d/test/integration/event-handler-test.ts#L69

Thanks for #435!