### PR TITLE
fix(types): .receive() and .verifyAndReceive() consistency

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -1,5 +1,4 @@
 import type {
-  EmitterAnyEvent,
   EmitterEventName,
   EmitterWebhookEvent,
   HandlerFunction,
@@ -20,7 +19,7 @@ interface EventHandler<TTransformed = unknown> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ): void;
-  onAny(handler: (event: EmitterAnyEvent) => any): void;
+  onAny(handler: (event: EmitterWebhookEvent) => any): void;
   onError(handler: (event: WebhookEventHandlerError) => any): void;
   removeListener<E extends EmitterEventName>(
     event: E | E[],

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,6 +1,6 @@
 import { emitterEventNames } from "../generated/webhook-names";
 import {
-  EmitterAnyEvent,
+  EmitterWebhookEvent,
   EmitterEventName,
   State,
   WebhookEventHandlerError,
@@ -49,7 +49,7 @@ export function receiverOn(
 
 export function receiverOnAny(
   state: State,
-  handler: (event: EmitterAnyEvent) => any
+  handler: (event: EmitterWebhookEvent) => any
 ) {
   handleEventHandlers(state, "*", handler);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from "./middleware/verify-and-receive";
 import { sign } from "./sign/index";
 import {
-  EmitterAnyEvent,
   EmitterEventName,
   EmitterWebhookEvent,
   EmitterWebhookEventMap,
@@ -31,7 +30,7 @@ class Webhooks<
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ) => void;
-  public onAny: (callback: (event: EmitterAnyEvent) => any) => void;
+  public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
   public removeListener: <E extends EmitterEventName>(
     event: E | E[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,11 @@ import { IncomingMessage, ServerResponse } from "http";
 import { createEventHandler } from "./event-handler/index";
 import { createMiddleware } from "./middleware/index";
 import { middleware } from "./middleware/middleware";
-import {
-  verifyAndReceive,
-  WebhookEventName,
-} from "./middleware/verify-and-receive";
+import { verifyAndReceive } from "./middleware/verify-and-receive";
 import { sign } from "./sign/index";
 import {
   EmitterEventName,
   EmitterWebhookEvent,
-  EmitterWebhookEventMap,
   HandlerFunction,
   Options,
   State,
@@ -43,7 +39,7 @@ class Webhooks<
     next?: (err?: any) => void
   ) => void | Promise<void>;
   public verifyAndReceive: (
-    options: EmitterWebhookEventMap[WebhookEventName] & { signature: string }
+    options: EmitterWebhookEvent & { signature: string }
   ) => Promise<void>;
 
   constructor(options?: Options<E>) {

--- a/src/middleware/verify-and-receive.ts
+++ b/src/middleware/verify-and-receive.ts
@@ -1,12 +1,9 @@
-import { EventPayloadMap } from "@octokit/webhooks-definitions/schema";
 import { verify } from "../verify/index";
-import { State, EmitterWebhookEventMap } from "../types";
-
-export type WebhookEventName = keyof EventPayloadMap;
+import { State, EmitterWebhookEvent } from "../types";
 
 export function verifyAndReceive(
   state: State,
-  event: EmitterWebhookEventMap[WebhookEventName] & { signature: string }
+  event: EmitterWebhookEvent & { signature: string }
 ): any {
   // verify will validate that the secret is not undefined
   const matchesSignature = verify(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 import type { RequestError } from "@octokit/request-error";
-import type { Schema } from "@octokit/webhooks-definitions/schema";
+import type {
+  Schema,
+  WebhookEventName,
+} from "@octokit/webhooks-definitions/schema";
 import type { EmitterEventWebhookPayloadMap } from "./generated/get-webhook-payload-type-from-event";
 
 type EmitterEventPayloadMap = { "*": Schema } & EmitterEventWebhookPayloadMap;
@@ -9,7 +12,7 @@ export type EmitterWebhookEventMap = {
 };
 
 export type EmitterWebhookEventName = keyof EmitterWebhookEventMap;
-export type EmitterWebhookEvent = EmitterWebhookEventMap[EmitterWebhookEventName];
+export type EmitterWebhookEvent = EmitterWebhookEventMap[WebhookEventName];
 
 /**
  * A map of all possible emitter events to their event type.

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,6 @@ export type EmitterEventMap = EmitterWebhookEventMap & {
 export type EmitterEventName = keyof EmitterEventMap;
 export type EmitterEvent = EmitterEventMap[EmitterEventName];
 
-export type EmitterAnyEvent = EmitterWebhookEventMap["*"];
-
 export type ToWebhookEvent<
   TEmitterEvent extends string
 > = TEmitterEvent extends `${infer TWebhookEvent}.${string}`

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -18,25 +18,10 @@ import { HandlerFunction, EmitterWebhookEventName } from "../src/types";
 // ************************************************************
 
 const fn = (webhookEvent: EmitterWebhookEvent) => {
-  if (webhookEvent.name === "*") {
-    if (
-      "action" in webhookEvent.payload &&
-      webhookEvent.payload.action === "completed"
-    ) {
-      console.log(webhookEvent.payload.sender);
-    }
-  }
   // @ts-expect-error TS2367:
-  //  This condition will always return 'false' since the types '"*" | "check_run" | ... many more ... | "workflow_run"' and '"check_run.completed"' have no overlap.
+  //  This condition will always return 'false' since the types '"check_run" | ... many more ... | "workflow_run"' and '"check_run.completed"' have no overlap.
   if (webhookEvent.name === "check_run.completed") {
     //
-  }
-
-  if (webhookEvent.name === "*") {
-    // @ts-expect-error TS2339:
-    //  Property 'action' does not exist on type 'Schema'.
-    //    Property 'action' does not exist on type 'CreateEvent'.
-    console.log(webhookEvent.payload.action);
   }
 };
 


### PR DESCRIPTION
- Use `EmitterWebhookEvent` for `.verifyAndReceive()`, same as `.receive()`
- Drop `"*"` from `EmitterWebhookEvent#name`. `event.name` already won't be `"*"` (before and after #444). This is currently reflected in the `.verifyAndReceive()` type -- this PR fixes `.receive()` to match. The consequent changes to `typescript-validate.ts` are cribbed from #444.

I'm happy to rebase this PR on #444!