### PR TITLE
refactor(types): rename EmitterWebhookEventName -> EmitterEventName

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
   - [webhooks.middleware()](#webhooksmiddleware)
   - [Webhook events](#webhook-events)
 - [TypeScript](#typescript)
-  - [`EmitterWebhookEventName`](#emitterwebhookeventname)
-  - [`EmitterWebhookEvent`](#emitterwebhookevent)
+  - [`EmitterEventName`](#emittereventname)
+  - [`EmitterEvent`](#emitterevent)
 - [License](#license)
 
 <!-- tocstop -->
@@ -652,11 +652,11 @@ In addition to these types, `@octokit/webhooks` exports 2 types specific to itse
 
 Note that changes to the exported types are not considered breaking changes, as the changes will not impact production code, but only fail locally or during CI at build time.
 
-### `EmitterWebhookEventName`
+### `EmitterEventName`
 
 A union of all possible events supported by the event emitter.
 
-### `EmitterWebhookEvent`
+### `EmitterEvent`
 
 The object that is emitted by `@octokit/webhooks` as an event; made up of an `id`, `name`, and `payload` properties.
 An optional generic parameter can be passed to narrow the type of the `payload` property to be based on the `name` of the event.

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -1,6 +1,6 @@
 import type {
-  EmitterWebhookEvent,
-  EmitterWebhookEventName,
+  EmitterEvent,
+  EmitterEventName,
   HandlerFunction,
   Options,
   State,
@@ -15,17 +15,17 @@ import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 
 interface EventHandler<TTransformed = unknown> {
-  on<E extends EmitterWebhookEventName>(
+  on<E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ): void;
-  onAny(handler: (event: EmitterWebhookEvent) => any): void;
+  onAny(handler: (event: EmitterEvent) => any): void;
   onError(handler: (event: WebhookEventHandlerError) => any): void;
-  removeListener<E extends EmitterWebhookEventName>(
+  removeListener<E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ): void;
-  receive(event: EmitterWebhookEvent): Promise<void>;
+  receive(event: EmitterEvent): Promise<void>;
 }
 
 export function createEventHandler(options: Options<any>): EventHandler {

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -4,7 +4,7 @@ import type {
   HandlerFunction,
   Options,
   State,
-  WebhookEventHandlerError,
+  EmitterError,
 } from "../types";
 import {
   receiverOn as on,
@@ -20,7 +20,7 @@ interface EventHandler<TTransformed = unknown> {
     callback: HandlerFunction<E, TTransformed>
   ): void;
   onAny(handler: (event: EmitterEvent) => any): void;
-  onError(handler: (event: WebhookEventHandlerError) => any): void;
+  onError(handler: (event: EmitterError) => any): void;
   removeListener<E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,10 +1,5 @@
 import { emitterEventNames } from "../generated/webhook-names";
-import {
-  EmitterEvent,
-  EmitterEventName,
-  State,
-  WebhookEventHandlerError,
-} from "../types";
+import { EmitterEvent, EmitterEventName, State, EmitterError } from "../types";
 
 function handleEventHandlers(
   state: State,
@@ -58,7 +53,7 @@ export function receiverOnAny(
 
 export function receiverOnError(
   state: State,
-  handler: (event: WebhookEventHandlerError) => any
+  handler: (event: EmitterError) => any
 ) {
   handleEventHandlers(state, "error", handler);
 }

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,14 +1,14 @@
 import { emitterEventNames } from "../generated/webhook-names";
 import {
-  EmitterWebhookEvent,
-  EmitterWebhookEventName,
+  EmitterEvent,
+  EmitterEventName,
   State,
   WebhookEventHandlerError,
 } from "../types";
 
 function handleEventHandlers(
   state: State,
-  webhookName: EmitterWebhookEventName | "error" | "*",
+  webhookName: EmitterEventName | "error" | "*",
   handler: Function
 ) {
   if (!state.hooks[webhookName]) {
@@ -19,7 +19,7 @@ function handleEventHandlers(
 }
 export function receiverOn(
   state: State,
-  webhookNameOrNames: EmitterWebhookEventName | EmitterWebhookEventName[],
+  webhookNameOrNames: EmitterEventName | EmitterEventName[],
   handler: Function
 ) {
   if (Array.isArray(webhookNameOrNames)) {
@@ -51,7 +51,7 @@ export function receiverOn(
 
 export function receiverOnAny(
   state: State,
-  handler: (event: EmitterWebhookEvent) => any
+  handler: (event: EmitterEvent) => any
 ) {
   handleEventHandlers(state, "*", handler);
 }

--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -5,7 +5,7 @@ import type {
   EmitterEventName,
   State,
   WebhookError,
-  WebhookEventHandlerError,
+  EmitterError,
 } from "../types";
 import { wrapErrorHandler } from "./wrap-error-handler";
 
@@ -83,7 +83,7 @@ export function receiverHandle(state: State, event: EmitterEvent) {
       return;
     }
 
-    const error = new AggregateError(errors) as WebhookEventHandlerError;
+    const error = new AggregateError(errors) as EmitterError;
     Object.assign(error, {
       event,
       errors,

--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -1,8 +1,8 @@
 // @ts-ignore to address #245
 import AggregateError from "aggregate-error";
 import type {
-  EmitterWebhookEvent,
-  EmitterWebhookEventName,
+  EmitterEvent,
+  EmitterEventName,
   State,
   WebhookError,
   WebhookEventHandlerError,
@@ -10,14 +10,14 @@ import type {
 import { wrapErrorHandler } from "./wrap-error-handler";
 
 type EventAction = Extract<
-  EmitterWebhookEvent["payload"],
+  EmitterEvent["payload"],
   { action: string }
 >["action"];
 
 function getHooks(
   state: State,
   eventPayloadAction: EventAction | null,
-  eventName: EmitterWebhookEventName
+  eventName: EmitterEventName
 ): Function[] {
   const hooks = [state.hooks[eventName], state.hooks["*"]];
 
@@ -29,7 +29,7 @@ function getHooks(
 }
 
 // main handler function
-export function receiverHandle(state: State, event: EmitterWebhookEvent) {
+export function receiverHandle(state: State, event: EmitterEvent) {
   const errorHandlers = state.hooks.error || [];
 
   if (event instanceof Error) {

--- a/src/event-handler/remove-listener.ts
+++ b/src/event-handler/remove-listener.ts
@@ -1,8 +1,8 @@
-import { EmitterWebhookEventName, State } from "../types";
+import { EmitterEventName, State } from "../types";
 
 export function removeListener(
   state: State,
-  webhookNameOrNames: EmitterWebhookEventName | EmitterWebhookEventName[],
+  webhookNameOrNames: EmitterEventName | EmitterEventName[],
   handler: Function
 ) {
   if (Array.isArray(webhookNameOrNames)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   Options,
   State,
   WebhookError,
-  WebhookEventHandlerError,
+  EmitterError,
 } from "./types";
 import { verify } from "./verify/index";
 
@@ -24,7 +24,7 @@ class Webhooks<E extends EmitterEvent = EmitterEvent, TTransformed = unknown> {
     callback: HandlerFunction<E, TTransformed>
   ) => void;
   public onAny: (callback: (event: EmitterEvent) => any) => void;
-  public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
+  public onError: (callback: (event: EmitterError) => any) => void;
   public removeListener: <E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import { middleware } from "./middleware/middleware";
 import { verifyAndReceive } from "./middleware/verify-and-receive";
 import { sign } from "./sign/index";
 import {
-  EmitterWebhookEvent,
-  EmitterWebhookEventName,
+  EmitterEvent,
+  EmitterEventName,
   HandlerFunction,
   Options,
   State,
@@ -16,30 +16,27 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<
-  E extends EmitterWebhookEvent = EmitterWebhookEvent,
-  TTransformed = unknown
-> {
+class Webhooks<E extends EmitterEvent = EmitterEvent, TTransformed = unknown> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
-  public on: <E extends EmitterWebhookEventName>(
+  public on: <E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ) => void;
-  public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
+  public onAny: (callback: (event: EmitterEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
-  public removeListener: <E extends EmitterWebhookEventName>(
+  public removeListener: <E extends EmitterEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ) => void;
-  public receive: (event: EmitterWebhookEvent) => Promise<void>;
+  public receive: (event: EmitterEvent) => Promise<void>;
   public middleware: (
     request: IncomingMessage,
     response: ServerResponse,
     next?: (err?: any) => void
   ) => void | Promise<void>;
   public verifyAndReceive: (
-    options: EmitterWebhookEvent & { signature: string }
+    options: EmitterEvent & { signature: string }
   ) => Promise<void>;
 
   constructor(options?: Options<E, TTransformed>) {
@@ -73,7 +70,7 @@ export {
   createMiddleware,
   createWebhooksApi,
   Webhooks,
-  EmitterWebhookEvent,
+  EmitterEvent,
   WebhookError,
   sign,
   verify,

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -5,7 +5,7 @@ import { getPayload } from "./get-payload";
 import { verifyAndReceive } from "./verify-and-receive";
 import { debug } from "debug";
 import { IncomingMessage, ServerResponse } from "http";
-import { State, WebhookEventHandlerError } from "../types";
+import { State, EmitterError } from "../types";
 
 const debugWebhooks = debug("webhooks:receiver");
 
@@ -77,7 +77,7 @@ export function middleware(
       response.end("ok\n");
     })
 
-    .catch((error: WebhookEventHandlerError) => {
+    .catch((error: EmitterError) => {
       clearTimeout(timeout);
 
       if (didTimeout) return;

--- a/src/middleware/verify-and-receive.ts
+++ b/src/middleware/verify-and-receive.ts
@@ -1,9 +1,9 @@
-import { EmitterWebhookEvent, State } from "../types";
+import { EmitterEvent, State } from "../types";
 import { verify } from "../verify/index";
 
 export function verifyAndReceive(
   state: State,
-  event: EmitterWebhookEvent & { signature: string }
+  event: EmitterEvent & { signature: string }
 ): any {
   // verify will validate that the secret is not undefined
   const matchesSignature = verify(

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,7 @@ export interface State extends Options<any> {
  */
 export type WebhookError = Error & Partial<RequestError>;
 
-// todo: rename to "EmitterErrorEvent"
-export interface WebhookEventHandlerError extends AggregateError<WebhookError> {
+export interface EmitterError extends AggregateError<WebhookError> {
   event: EmitterEvent;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,38 +5,34 @@ import type {
 } from "@octokit/webhooks-definitions/schema";
 import type { emitterEventNames } from "./generated/webhook-names";
 
-export type EmitterWebhookEventName = typeof emitterEventNames[number];
-export type EmitterWebhookEvent<
-  TEmitterEvent extends EmitterWebhookEventName = EmitterWebhookEventName
+export type EmitterEventName = typeof emitterEventNames[number];
+export type EmitterEvent<
+  TEmitterEvent extends EmitterEventName = EmitterEventName
 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
-  ? BaseWebhookEvent<Extract<TWebhookEvent, WebhookEventName>> & {
+  ? BaseEmitterEvent<Extract<TWebhookEvent, WebhookEventName>> & {
       payload: { action: TAction };
     }
-  : BaseWebhookEvent<Extract<TEmitterEvent, WebhookEventName>>;
+  : BaseEmitterEvent<Extract<TEmitterEvent, WebhookEventName>>;
 
-interface BaseWebhookEvent<TName extends WebhookEventName> {
+interface BaseEmitterEvent<TName extends WebhookEventName> {
   id: string;
   name: TName;
   payload: WebhookEventMap[TName];
 }
 
-export interface Options<
-  T extends EmitterWebhookEvent,
-  TTransformed = unknown
-> {
+export interface Options<T extends EmitterEvent, TTransformed = unknown> {
   path?: string;
   secret?: string;
   transform?: TransformMethod<T, TTransformed>;
 }
 
-type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
-  event: EmitterWebhookEvent
+type TransformMethod<T extends EmitterEvent, V = T> = (
+  event: EmitterEvent
 ) => V | PromiseLike<V>;
 
-export type HandlerFunction<
-  TName extends EmitterWebhookEventName,
-  TTransformed
-> = (event: EmitterWebhookEvent<TName> & TTransformed) => any;
+export type HandlerFunction<TName extends EmitterEventName, TTransformed> = (
+  event: EmitterEvent<TName> & TTransformed
+) => any;
 
 type Hooks = {
   [key: string]: Function[];
@@ -54,7 +50,7 @@ export type WebhookError = Error & Partial<RequestError>;
 
 // todo: rename to "EmitterErrorEvent"
 export interface WebhookEventHandlerError extends AggregateError<WebhookError> {
-  event: EmitterWebhookEvent;
+  event: EmitterEvent;
 }
 
 /**

--- a/test/integration/event-handler-test.ts
+++ b/test/integration/event-handler-test.ts
@@ -1,5 +1,5 @@
 import { createEventHandler } from "../../src/event-handler";
-import { EmitterEvent, WebhookEventHandlerError } from "../../src/types";
+import { EmitterEvent, EmitterError } from "../../src/types";
 import { installationCreatedPayload, pushEventPayload } from "../fixtures";
 
 test("events", async () => {
@@ -105,7 +105,7 @@ describe("when a handler throws an error", () => {
     });
 
     return new Promise<void>(async (resolve) => {
-      eventHandler.onError((error: WebhookEventHandlerError) => {
+      eventHandler.onError((error: EmitterError) => {
         expect(error.event.payload).toBeTruthy();
         expect(error.message).toMatch(/oops/);
 

--- a/test/integration/event-handler-test.ts
+++ b/test/integration/event-handler-test.ts
@@ -1,5 +1,5 @@
 import { createEventHandler } from "../../src/event-handler";
-import { EmitterWebhookEvent, WebhookEventHandlerError } from "../../src/types";
+import { EmitterEvent, WebhookEventHandlerError } from "../../src/types";
 import { installationCreatedPayload, pushEventPayload } from "../fixtures";
 
 test("events", async () => {
@@ -26,7 +26,7 @@ test("events", async () => {
   function hook6() {
     hooksCalled.push("installation.created");
   }
-  function hook7(event: EmitterWebhookEvent) {
+  function hook7(event: EmitterEvent) {
     hooksCalled.push(`* (${event.name})`);
   }
 
@@ -135,7 +135,7 @@ test("options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: EmitterWebhookEvent) => {
+  eventHandler.on("push", (event: EmitterEvent) => {
     expect(event).toBe("funky");
 
     done();
@@ -155,7 +155,7 @@ test("async options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: EmitterWebhookEvent) => {
+  eventHandler.on("push", (event: EmitterEvent) => {
     expect(event).toBe("funky");
     done();
   });

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -5,17 +5,17 @@ import {
   createWebhooksApi,
   sign,
   verify,
-  EmitterWebhookEvent,
+  EmitterEvent,
   WebhookError,
 } from "../src/index";
 import { createServer } from "http";
-import { HandlerFunction, EmitterWebhookEventName } from "../src/types";
+import { HandlerFunction, EmitterEventName } from "../src/types";
 
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS FOR TYPECHECKING ONLY
 // ************************************************************
 
-const fn = (webhookEvent: EmitterWebhookEvent) => {
+const fn = (webhookEvent: EmitterEvent) => {
   // @ts-expect-error TS2367:
   //  This condition will always return 'false' since the types '"check_run" | ... many more ... | "workflow_run"' and '"check_run.completed"' have no overlap.
   if (webhookEvent.name === "check_run.completed") {
@@ -23,7 +23,7 @@ const fn = (webhookEvent: EmitterWebhookEvent) => {
   }
 };
 
-declare const on: <E extends EmitterWebhookEventName>(
+declare const on: <E extends EmitterEventName>(
   name: E | E[],
   callback: HandlerFunction<E, unknown>
 ) => void;

--- a/test/unit/event-handler-on-test.ts
+++ b/test/unit/event-handler-on-test.ts
@@ -1,5 +1,5 @@
 import { receiverOn } from "../../src/event-handler/on";
-import { EmitterWebhookEventName, State } from "../../src/types";
+import { EmitterEventName, State } from "../../src/types";
 
 function noop() {}
 
@@ -23,16 +23,14 @@ test("receiver.on with invalid event name", () => {
 });
 
 test("receiver.on with event name of '*' throws an error", () => {
-  expect(() =>
-    receiverOn(state, "*" as EmitterWebhookEventName, noop)
-  ).toThrowError(
+  expect(() => receiverOn(state, "*" as EmitterEventName, noop)).toThrowError(
     'Using the "*" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onAny() method instead'
   );
 });
 
 test("receiver.on with event name of 'error' throws an error", () => {
   expect(() =>
-    receiverOn(state, "error" as EmitterWebhookEventName, noop)
+    receiverOn(state, "error" as EmitterEventName, noop)
   ).toThrowError(
     'Using the "error" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onError() method instead'
   );


### PR DESCRIPTION
Is there any objection to renaming `EmitterWebhookEventName` -> `EmitterEventName`, now that `"*"` and `"error"` have been removed?
- https://github.com/octokit/webhooks.js/pull/444#issuecomment-774778669
- https://github.com/octokit/webhooks.js/pull/444#discussion_r572263542

-----
[View rendered README.md](https://github.com/jablko/webhooks.js/blob/patch-5/README.md)