### PR TITLE
feat(logging): add log option

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config.InitialOptions = {
     },
   },
   preset: "ts-jest",
+  restoreMocks: true,
   testEnvironment: "node",
   testRegex: /test\/.*\/.*.test.ts/u.source,
 };

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -32,8 +32,8 @@ export function createEventHandler(options: Options<any>): EventHandler {
   const state: State = {
     hooks: {},
     log: {
-      debug: () => {},
-      info: () => {},
+      debug: /* istanbul ignore next: unused */ () => {},
+      info: /* istanbul ignore next: unused */ () => {},
       warn: console.warn.bind(console),
       error: console.error.bind(console),
       ...options.log,

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -2,6 +2,7 @@ import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
   HandlerFunction,
+  Logger,
   Options,
   State,
   WebhookEventHandlerError,
@@ -31,13 +32,7 @@ interface EventHandler<TTransformed = unknown> {
 export function createEventHandler(options: Options<any>): EventHandler {
   const state: State = {
     hooks: {},
-    log: {
-      debug: /* istanbul ignore next: unused */ () => {},
-      info: /* istanbul ignore next: unused */ () => {},
-      warn: console.warn.bind(console),
-      error: console.error.bind(console),
-      ...options.log,
-    },
+    log: createLogger(options.log),
   };
 
   if (options && options.transform) {
@@ -50,5 +45,15 @@ export function createEventHandler(options: Options<any>): EventHandler {
     onError: onError.bind(null, state),
     removeListener: removeListener.bind(null, state),
     receive: receive.bind(null, state),
+  };
+}
+
+export function createLogger(logger?: Partial<Logger>) {
+  return {
+    debug: () => {},
+    info: /* istanbul ignore next: unused */ () => {},
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    ...logger,
   };
 }

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -31,6 +31,13 @@ interface EventHandler<TTransformed = unknown> {
 export function createEventHandler(options: Options<any>): EventHandler {
   const state: State = {
     hooks: {},
+    log: {
+      debug: () => {},
+      info: () => {},
+      warn: console.warn.bind(console),
+      error: console.error.bind(console),
+      ...options.log,
+    },
   };
 
   if (options && options.transform) {

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -41,7 +41,7 @@ export function receiverOn(
   }
 
   if (emitterEventNames.indexOf(webhookNameOrNames) === -1) {
-    console.warn(
+    state.log.warn(
       `"${webhookNameOrNames}" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)`
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,13 @@ class Webhooks<
       path: options.path || "/",
       secret: options.secret,
       hooks: {},
+      log: {
+        debug: () => {},
+        info: () => {},
+        warn: console.warn.bind(console),
+        error: console.error.bind(console),
+        ...options.log,
+      },
     };
 
     this.sign = sign.bind(null, options.secret);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { IncomingMessage, ServerResponse } from "http";
-import { createEventHandler } from "./event-handler/index";
+import { createEventHandler, createLogger } from "./event-handler/index";
 import { createMiddleware } from "./middleware/index";
 import { middleware } from "./middleware/middleware";
 import { verifyAndReceive } from "./middleware/verify-and-receive";
@@ -52,13 +52,7 @@ class Webhooks<
       path: options.path || "/",
       secret: options.secret,
       hooks: {},
-      log: {
-        debug: () => {},
-        info: /* istanbul ignore next: unused */ () => {},
-        warn: console.warn.bind(console),
-        error: console.error.bind(console),
-        ...options.log,
-      },
+      log: createLogger(options.log),
     };
 
     this.sign = sign.bind(null, options.secret);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ class Webhooks<
       hooks: {},
       log: {
         debug: () => {},
-        info: () => {},
+        info: /* istanbul ignore next: unused */ () => {},
         warn: console.warn.bind(console),
         error: console.error.bind(console),
         ...options.log,

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,3 +1,4 @@
+import { debug } from "debug";
 import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
 import { Options, State } from "../types";
@@ -13,7 +14,7 @@ export function createMiddleware(options: Options<any>) {
     secret: options.secret,
     hooks: {},
     log: {
-      debug: () => {},
+      debug: options.log ? () => {} : debug("webhooks:receiver"),
       info: /* istanbul ignore next: unused */ () => {},
       warn: console.warn.bind(console),
       error: console.error.bind(console),

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -12,6 +12,13 @@ export function createMiddleware(options: Options<any>) {
     path: options.path || "/",
     secret: options.secret,
     hooks: {},
+    log: {
+      debug: () => {},
+      info: () => {},
+      warn: console.warn.bind(console),
+      error: console.error.bind(console),
+      ...options.log,
+    },
   };
 
   const api: any = middleware.bind(null, state);

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -14,7 +14,7 @@ export function createMiddleware(options: Options<any>) {
     hooks: {},
     log: {
       debug: () => {},
-      info: () => {},
+      info: /* istanbul ignore next: unused */ () => {},
       warn: console.warn.bind(console),
       error: console.error.bind(console),
       ...options.log,

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,5 +1,5 @@
 import { debug } from "debug";
-import { createEventHandler } from "../event-handler/index";
+import { createEventHandler, createLogger } from "../event-handler/index";
 import { middleware } from "./middleware";
 import { Options, State } from "../types";
 
@@ -13,13 +13,7 @@ export function createMiddleware(options: Options<any>) {
     path: options.path || "/",
     secret: options.secret,
     hooks: {},
-    log: {
-      debug: options.log ? () => {} : debug("webhooks:receiver"),
-      info: /* istanbul ignore next: unused */ () => {},
-      warn: console.warn.bind(console),
-      error: console.error.bind(console),
-      ...options.log,
-    },
+    log: createLogger(options.log || { debug: debug("webhooks:receiver") }),
   };
 
   const api: any = middleware.bind(null, state);

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -3,11 +3,8 @@ import { isntWebhook } from "./isnt-webhook";
 import { getMissingHeaders } from "./get-missing-headers";
 import { getPayload } from "./get-payload";
 import { verifyAndReceive } from "./verify-and-receive";
-import { debug } from "debug";
 import { IncomingMessage, ServerResponse } from "http";
 import { State, WebhookEventHandlerError } from "../types";
-
-const debugWebhooks = debug("webhooks:receiver");
 
 export function middleware(
   state: State,
@@ -25,7 +22,6 @@ export function middleware(
       return;
     }
 
-    debugWebhooks(`ignored: ${request.method} ${request.url}`);
     state.log.debug(`ignored: ${request.method} ${request.url}`);
     response.statusCode = 404;
     response.end("Not found");
@@ -49,7 +45,6 @@ export function middleware(
   const signatureSHA256 = request.headers["x-hub-signature-256"] as string;
   const id = request.headers["x-github-delivery"] as string;
 
-  debugWebhooks(`${eventName} event received (id: ${id})`);
   state.log.debug(`${eventName} event received (id: ${id})`);
 
   // GitHub will abort the request if it does not receive a response within 10s

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -26,6 +26,7 @@ export function middleware(
     }
 
     debugWebhooks(`ignored: ${request.method} ${request.url}`);
+    state.log.debug(`ignored: ${request.method} ${request.url}`);
     response.statusCode = 404;
     response.end("Not found");
     return;
@@ -49,6 +50,7 @@ export function middleware(
   const id = request.headers["x-github-delivery"] as string;
 
   debugWebhooks(`${eventName} event received (id: ${id})`);
+  state.log.debug(`${eventName} event received (id: ${id})`);
 
   // GitHub will abort the request if it does not receive a response within 10s
   // See https://github.com/octokit/webhooks.js/issues/185

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface Options<
   path?: string;
   secret?: string;
   transform?: TransformMethod<T, TTransformed>;
+  log?: Partial<State["log"]>;
 }
 
 type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
@@ -45,6 +46,12 @@ type Hooks = {
 export interface State extends Options<any> {
   eventHandler?: any;
   hooks: Hooks;
+  log: {
+    debug: (message: string) => unknown;
+    info: (message: string) => unknown;
+    warn: (message: string) => unknown;
+    error: (message: string) => unknown;
+  };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface Options<
   path?: string;
   secret?: string;
   transform?: TransformMethod<T, TTransformed>;
-  log?: Partial<State["log"]>;
+  log?: Partial<Logger>;
 }
 
 type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
@@ -43,15 +43,17 @@ type Hooks = {
   [key: string]: Function[];
 };
 
+export interface Logger {
+  debug: (message: string) => unknown;
+  info: (message: string) => unknown;
+  warn: (message: string) => unknown;
+  error: (message: string) => unknown;
+}
+
 export interface State extends Options<any> {
   eventHandler?: any;
   hooks: Hooks;
-  log: {
-    debug: (message: string) => unknown;
-    info: (message: string) => unknown;
-    warn: (message: string) => unknown;
-    error: (message: string) => unknown;
-  };
+  log: Logger;
 }
 
 /**

--- a/test/integration/middleware-test.ts
+++ b/test/integration/middleware-test.ts
@@ -33,7 +33,7 @@ test("Invalid payload", () => {
     statusCode: 0,
   };
 
-  const middleware = createMiddleware({ secret: "mysecret" });
+  const middleware = createMiddleware({ secret: "mysecret", log: {} });
   const middlewareDone = middleware(requestMock, responseMock).then(() => {
     expect(responseMock.statusCode).toBe(400);
     expect(responseMock.end).toHaveBeenCalledWith(
@@ -61,7 +61,7 @@ test("request error", () => {
     statusCode: 0,
   };
 
-  const middleware = createMiddleware({ secret: "mysecret" });
+  const middleware = createMiddleware({ secret: "mysecret", log: {} });
   const middlewareDone = middleware(requestMock, responseMock).then(() => {
     expect(responseMock.statusCode).toBe(500);
     expect(responseMock.end).toHaveBeenCalledWith(

--- a/test/unit/event-handler-on-test.ts
+++ b/test/unit/event-handler-on-test.ts
@@ -5,6 +5,7 @@ function noop() {}
 
 const state: State = {
   hooks: {},
+  log: console,
 };
 
 beforeEach(() => jest.resetAllMocks());

--- a/test/unit/event-handler-receive-test.ts
+++ b/test/unit/event-handler-receive-test.ts
@@ -4,6 +4,7 @@ import { State } from "../../src/types";
 const state: State = {
   secret: "mysecret",
   hooks: {},
+  log: console,
 };
 
 test("options: none", () => {

--- a/test/unit/event-handler-remove-listener-test.ts
+++ b/test/unit/event-handler-remove-listener-test.ts
@@ -8,10 +8,11 @@ test("remove-listener: single listener", () => {
     hooks: {
       push: [push],
     },
+    log: console,
   };
 
   expect(() => removeListener(state, "push", push)).not.toThrow();
-  expect(state).toStrictEqual({ hooks: { push: [] } });
+  expect(state).toStrictEqual({ hooks: { push: [] }, log: console });
 });
 
 test("remove-listener: multiple listeners", () => {
@@ -26,6 +27,7 @@ test("remove-listener: multiple listeners", () => {
       push: [push1, push2, push3],
       ping: [ping],
     },
+    log: console,
   };
 
   expect(() => {
@@ -33,5 +35,8 @@ test("remove-listener: multiple listeners", () => {
     removeListener(state, "push", push2);
     removeListener(state, "push", push3);
   }).not.toThrow();
-  expect(state).toStrictEqual({ hooks: { push: [], ping: [ping] } });
+  expect(state).toStrictEqual({
+    hooks: { push: [], ping: [ping] },
+    log: console,
+  });
 });

--- a/test/unit/middleware-test.ts
+++ b/test/unit/middleware-test.ts
@@ -1,16 +1,19 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { middleware } from "../../src/middleware/middleware";
-import { getMissingHeaders } from "../../src/middleware/get-missing-headers";
 import { getPayload } from "../../src/middleware/get-payload";
 import { verifyAndReceive } from "../../src/middleware/verify-and-receive";
 
-jest.mock("../../src/middleware/get-missing-headers");
 jest.mock("../../src/middleware/get-payload");
 jest.mock("../../src/middleware/verify-and-receive");
 
-const mockGetMissingHeaders = getMissingHeaders as jest.Mock;
 const mockGetPayload = getPayload as jest.Mock;
 const mockVerifyAndReceive = verifyAndReceive as jest.Mock;
+
+const headers = {
+  "x-github-delivery": "123e4567-e89b-12d3-a456-426655440000",
+  "x-github-event": "push",
+  "x-hub-signature": "sha1=f4d795e69b5d03c139cc6ea991ad3e5762d13e2f",
+};
 
 test("next() callback", () => {
   const next = jest.fn();
@@ -34,20 +37,20 @@ describe("when does a timeout on retrieving the payload", () => {
   });
 
   test("successfully, does NOT response.end(ok)", async () => {
+    const consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation();
     const responseMock = ({ end: jest.fn() } as unknown) as ServerResponse;
     const next = jest.fn();
 
-    mockGetMissingHeaders.mockReturnValueOnce([]);
     mockGetPayload.mockResolvedValueOnce(undefined);
     mockVerifyAndReceive.mockResolvedValueOnce(undefined);
 
     const promiseMiddleware = middleware(
       { hooks: {}, path: "/foo", log: console },
-      {
+      ({
         method: "POST",
         url: "/foo",
-        headers: {},
-      } as IncomingMessage,
+        headers,
+      } as unknown) as IncomingMessage,
       responseMock,
       next
     );
@@ -57,26 +60,30 @@ describe("when does a timeout on retrieving the payload", () => {
     await promiseMiddleware;
 
     expect(next).not.toHaveBeenCalled();
+    expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
+    expect(consoleDebugSpy).toHaveBeenLastCalledWith(
+      "push event received (id: 123e4567-e89b-12d3-a456-426655440000)"
+    );
     expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(responseMock.end).toHaveBeenCalledWith("still processing\n");
     expect(responseMock.end).not.toHaveBeenCalledWith("ok\n");
   });
 
   test("failing, does NOT response.end(ok)", async () => {
+    const consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation();
     const responseMock = ({ end: jest.fn() } as unknown) as ServerResponse;
     const next = jest.fn();
 
-    mockGetMissingHeaders.mockReturnValueOnce([]);
     mockGetPayload.mockResolvedValueOnce(undefined);
     mockVerifyAndReceive.mockRejectedValueOnce(new Error("random error"));
 
     const promiseMiddleware = middleware(
       { hooks: {}, path: "/foo", log: console },
-      {
+      ({
         method: "POST",
         url: "/foo",
-        headers: {},
-      } as IncomingMessage,
+        headers,
+      } as unknown) as IncomingMessage,
       responseMock,
       next
     );
@@ -86,6 +93,10 @@ describe("when does a timeout on retrieving the payload", () => {
     await promiseMiddleware;
 
     expect(next).not.toHaveBeenCalled();
+    expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
+    expect(consoleDebugSpy).toHaveBeenLastCalledWith(
+      "push event received (id: 123e4567-e89b-12d3-a456-426655440000)"
+    );
     expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(responseMock.end).toHaveBeenCalledWith("still processing\n");
     expect(responseMock.end).not.toHaveBeenCalledWith(

--- a/test/unit/middleware-test.ts
+++ b/test/unit/middleware-test.ts
@@ -18,6 +18,7 @@ test("next() callback", () => {
   middleware(
     {
       hooks: {},
+      log: console,
     },
     { method: "POST", url: "/foo" } as IncomingMessage,
     {} as ServerResponse,
@@ -41,7 +42,7 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockResolvedValueOnce(undefined);
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo" },
+      { hooks: {}, path: "/foo", log: console },
       {
         method: "POST",
         url: "/foo",
@@ -70,7 +71,7 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockRejectedValueOnce(new Error("random error"));
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo" },
+      { hooks: {}, path: "/foo", log: console },
       {
         method: "POST",
         url: "/foo",


### PR DESCRIPTION
I'd like to be able to redirect the log messages, so I added a `{ log }` option, consistent with the other `@octokit/*` packages, based on this feedback https://github.com/octokit/webhooks.js/pull/201#pullrequestreview-463894384

@oscard0m is already working on this in #201 (where there's existing discussion/feedback) and I'm happy to set the base branch of this PR to https://github.com/octokit/webhooks.js/tree/use-conole-log-level-package-instead-of-debug-package, however I think that branch has been removed.

If you resurrect that branch I'm happy to request pulling this PR into it. Whichever you prefer! I want to contribute to, not supersede, #201 :heart: