### PR TITLE
fix(typescript): infer TTransformed from createEventHandler() options

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -14,7 +14,7 @@ import {
 import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 
-interface EventHandler<TTransformed = unknown> {
+interface EventHandler<TTransformed> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
@@ -28,7 +28,9 @@ interface EventHandler<TTransformed = unknown> {
   receive(event: EmitterWebhookEvent): Promise<void>;
 }
 
-export function createEventHandler(options: Options<any>): EventHandler {
+export function createEventHandler<TTransformed>(
+  options: Options<any, TTransformed>
+): EventHandler<TTransformed> {
   const state: State = {
     hooks: {},
   };


### PR DESCRIPTION
Should we get the `TTransformed` type from the `createEventHandler()` options, like with do with the `Webhooks` options? https://github.com/octokit/webhooks.js/blob/80ee43fc95d8853ba1439d55a54f1b9cee7813e1/src/index.ts#L45