### PR TITLE
refactor(typescript): simplify TransformMethod type

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -29,7 +29,7 @@ interface EventHandler<TTransformed> {
 }
 
 export function createEventHandler<TTransformed>(
-  options: Options<any, TTransformed>
+  options: Options<TTransformed>
 ): EventHandler<TTransformed> {
   const state: State = {
     hooks: {},

--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -66,7 +66,6 @@ export function receiverHandle(state: State, event: EmitterWebhookEvent) {
     let promise = Promise.resolve(event);
 
     if (state.transform) {
-      // @ts-expect-error
       promise = promise.then(state.transform);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,7 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<
-  E extends EmitterWebhookEvent = EmitterWebhookEvent,
-  TTransformed = unknown
-> {
+class Webhooks<TTransformed> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterWebhookEventName>(
@@ -42,7 +39,7 @@ class Webhooks<
     options: EmitterWebhookEvent & { signature: string }
   ) => Promise<void>;
 
-  constructor(options?: Options<E, TTransformed>) {
+  constructor(options?: Options<TTransformed>) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -2,7 +2,7 @@ import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
 import { Options, State } from "../types";
 
-export function createMiddleware(options: Options<any>) {
+export function createMiddleware(options: Options) {
   if (!options || !options.secret) {
     throw new Error("[@octokit/webhooks] options.secret required");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,18 +20,13 @@ interface BaseWebhookEvent<TName extends WebhookEventName> {
   payload: WebhookEventMap[TName];
 }
 
-export interface Options<
-  T extends EmitterWebhookEvent,
-  TTransformed = unknown
-> {
+export interface Options<TTransformed = unknown> {
   path?: string;
   secret?: string;
-  transform?: TransformMethod<T, TTransformed>;
+  transform?: TransformMethod<TTransformed>;
 }
 
-type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
-  event: EmitterWebhookEvent
-) => V | PromiseLike<V>;
+type TransformMethod<T> = (event: EmitterWebhookEvent) => T | PromiseLike<T>;
 
 export type HandlerFunction<
   TName extends EmitterWebhookEventName,


### PR DESCRIPTION
Can we simplify the `TransformMethod` type as follows?
```Diff
-type TransformMethod<T extends EmitterWebhookEvent, V = T> = (
+type TransformMethod<T> = (
   event: EmitterWebhookEvent
-) => V | PromiseLike<V>;
+) => T | PromiseLike<T>;
```