### PR TITLE
feat(typescript): compile-time missing secret error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,9 @@ class Webhooks<TTransformed = unknown> {
 }
 
 /** @deprecated `createWebhooksApi()` is deprecated and will be removed in a future release of `@octokit/webhooks`, please use the `Webhooks` class instead */
-const createWebhooksApi = <TTransformed>(options: Options<TTransformed>) => {
+const createWebhooksApi = <TTransformed>(
+  options: Options<TTransformed> & { secret: string }
+) => {
   const log = createLogger(options.log);
   log.warn(
     "[@octokit/webhooks] `createWebhooksApi()` is deprecated and will be removed in a future release of `@octokit/webhooks`, please use the `Webhooks` class instead"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   EmitterWebhookEventName,
   HandlerFunction,
   Options,
+  State,
   WebhookError,
   WebhookEventHandlerError,
 } from "./types";
@@ -50,7 +51,7 @@ class Webhooks<TTransformed = unknown> {
       throw new Error("[@octokit/webhooks] options.secret required");
     }
 
-    const state = {
+    const state: State & { secret: string } = {
       eventHandler: createEventHandler(options),
       path: options.path || "/",
       secret: options.secret,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import {
   EmitterWebhookEventName,
   HandlerFunction,
   Options,
-  State,
   WebhookError,
   WebhookEventHandlerError,
 } from "./types";
@@ -46,12 +45,12 @@ class Webhooks<TTransformed = unknown> {
     next?: (err?: any) => void
   ) => void | Promise<void>;
 
-  constructor(options: Options<TTransformed>) {
+  constructor(options: Options<TTransformed> & { secret: string }) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }
 
-    const state: State = {
+    const state = {
       eventHandler: createEventHandler(options),
       path: options.path || "/",
       secret: options.secret,

--- a/src/middleware-legacy/index.ts
+++ b/src/middleware-legacy/index.ts
@@ -2,14 +2,14 @@ import { debug } from "debug";
 import { createLogger } from "../createLogger";
 import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
-import { Options } from "../types";
+import { Options, State } from "../types";
 
 export function createMiddleware(options: Options & { secret: string }) {
   if (!options || !options.secret) {
     throw new Error("[@octokit/webhooks] options.secret required");
   }
 
-  const state = {
+  const state: State & { secret: string } = {
     eventHandler: createEventHandler(options),
     path: options.path || "/",
     secret: options.secret,

--- a/src/middleware-legacy/index.ts
+++ b/src/middleware-legacy/index.ts
@@ -2,14 +2,14 @@ import { debug } from "debug";
 import { createLogger } from "../createLogger";
 import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
-import { Options, State } from "../types";
+import { Options } from "../types";
 
-export function createMiddleware(options: Options) {
+export function createMiddleware(options: Options & { secret: string }) {
   if (!options || !options.secret) {
     throw new Error("[@octokit/webhooks] options.secret required");
   }
 
-  const state: State = {
+  const state = {
     eventHandler: createEventHandler(options),
     path: options.path || "/",
     secret: options.secret,

--- a/src/middleware-legacy/middleware.ts
+++ b/src/middleware-legacy/middleware.ts
@@ -7,7 +7,7 @@ import { IncomingMessage, ServerResponse } from "http";
 import { State, WebhookEventHandlerError } from "../types";
 
 export function middleware(
-  state: State,
+  state: State & { secret: string },
   request: IncomingMessage,
   response: ServerResponse,
   next?: Function

--- a/src/middleware-legacy/verify-and-receive.ts
+++ b/src/middleware-legacy/verify-and-receive.ts
@@ -2,15 +2,11 @@ import { EmitterWebhookEvent, State } from "../types";
 import { verify } from "../verify/index";
 
 export function verifyAndReceive(
-  state: State,
+  state: State & { secret: string },
   event: EmitterWebhookEvent & { signature: string }
 ): any {
   // verify will validate that the secret is not undefined
-  const matchesSignature = verify(
-    state.secret!,
-    event.payload,
-    event.signature
-  );
+  const matchesSignature = verify(state.secret, event.payload, event.signature);
 
   if (!matchesSignature) {
     const error = new Error(

--- a/test/unit/middleware-constructor-test.ts
+++ b/test/unit/middleware-constructor-test.ts
@@ -1,5 +1,6 @@
 import { createMiddleware as Middleware } from "../../src/middleware-legacy";
 
 test("options: none", () => {
+  // @ts-expect-error
   expect(() => Middleware({})).toThrow();
 });

--- a/test/unit/middleware-test.ts
+++ b/test/unit/middleware-test.ts
@@ -20,6 +20,7 @@ test("next() callback", () => {
 
   middleware(
     {
+      secret: "mysecret",
       hooks: {},
       log: console,
     },
@@ -45,7 +46,7 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockResolvedValueOnce(undefined);
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo", log: console },
+      { secret: "mysecret", hooks: {}, path: "/foo", log: console },
       ({
         method: "POST",
         url: "/foo",
@@ -78,7 +79,7 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockRejectedValueOnce(new Error("random error"));
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo", log: console },
+      { secret: "mysecret", hooks: {}, path: "/foo", log: console },
       ({
         method: "POST",
         url: "/foo",


### PR DESCRIPTION
Should this be a compile-time as well as a run-time error?
```Diff
--- a/test/unit/middleware-constructor-test.ts
+++ b/test/unit/middleware-constructor-test.ts
@@ -1,5 +1,6 @@
 import { createMiddleware as Middleware } from "../../src/middleware";
 
 test("options: none", () => {
+  // @ts-expect-error
   expect(() => Middleware({})).toThrow();
 });