### PR TITLE
fix(typescript): HandlerFunction argument

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -15,23 +15,23 @@ import {
 import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 
-interface EventHandler<TTransformed> {
+interface EventHandler<T extends Options> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, TTransformed>
+    callback: HandlerFunction<E, T["transform"]>
   ): void;
   onAny(handler: (event: EmitterWebhookEvent) => any): void;
   onError(handler: (event: WebhookEventHandlerError) => any): void;
   removeListener<E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, TTransformed>
+    callback: HandlerFunction<E, T["transform"]>
   ): void;
   receive(event: EmitterWebhookEvent): Promise<void>;
 }
 
-export function createEventHandler<TTransformed>(
-  options?: Options<TTransformed>
-): EventHandler<TTransformed> {
+export function createEventHandler<T extends Options>(
+  options?: T
+): EventHandler<T> {
   const state: State = {
     hooks: {},
     log: createLogger(options && options.log),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,18 +17,18 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<TTransformed> {
+class Webhooks<T extends Options> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, TTransformed>
+    callback: HandlerFunction<E, T["transform"]>
   ) => void;
   public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
   public removeListener: <E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, TTransformed>
+    callback: HandlerFunction<E, T["transform"]>
   ) => void;
   public receive: (event: EmitterWebhookEvent) => Promise<void>;
   public middleware: (
@@ -40,7 +40,7 @@ class Webhooks<TTransformed> {
     options: EmitterWebhookEvent & { signature: string }
   ) => Promise<void>;
 
-  constructor(options: Options<TTransformed>) {
+  constructor(options: T) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,12 @@ type TransformMethod<T> = (event: EmitterWebhookEvent) => T | PromiseLike<T>;
 
 export type HandlerFunction<
   TName extends EmitterWebhookEventName,
-  TTransformed
-> = (event: EmitterWebhookEvent<TName> & TTransformed) => any;
+  TTransform
+> = (
+  event: TTransform extends TransformMethod<infer T>
+    ? T
+    : EmitterWebhookEvent<TName>
+) => any;
 
 type Hooks = {
   [key: string]: Function[];

--- a/test/integration/event-handler-test.ts
+++ b/test/integration/event-handler-test.ts
@@ -135,7 +135,7 @@ test("options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: EmitterWebhookEvent) => {
+  eventHandler.on("push", (event: string) => {
     expect(event).toBe("funky");
 
     done();
@@ -155,7 +155,7 @@ test("async options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: EmitterWebhookEvent) => {
+  eventHandler.on("push", (event: string) => {
     expect(event).toBe("funky");
     done();
   });

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -72,10 +72,6 @@ export default async function () {
   const webhooks = new Webhooks({
     secret: "blah",
     path: "/webhooks",
-    transform: (event) => {
-      console.log(event.payload);
-      return Object.assign(event, { foo: "bar" });
-    },
   });
 
   // Check named exports of new API work
@@ -167,6 +163,17 @@ export default async function () {
 
   webhooks.on("issues", (event) => {
     console.log(event.payload.issue);
+  });
+}
+
+{
+  const webhooks = new Webhooks({
+    secret: "blah",
+    path: "/webhooks",
+    transform: (event) => {
+      console.log(event.payload);
+      return Object.assign(event, { foo: "bar" });
+    },
   });
 
   webhooks.on("issues", (event) => {


### PR DESCRIPTION
What do you think about revising `HandlerFunction` as follows, to make the argument `TTransformed` if the `transform` option is set and `EmitterWebhookEvent<TName>` if not, instead of always the intersection?
```Diff
--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,8 @@ type TransformMethod<T> = (event: EmitterWebhookEvent) => T | PromiseLike<T>;
 
 export type HandlerFunction<
   TName extends EmitterWebhookEventName,
-  TTransformed
-> = (event: EmitterWebhookEvent<TName> & TTransformed) => any;
+  TTransform
+> = (event: TTransform extends TransformMethod<infer T> ? T : EmitterWebhookEvent<TName>) => any;
 
 type Hooks = {
   [key: string]: Function[];
```

This fixes the types in cases like:
```Diff
--- a/test/integration/event-handler-test.ts
+++ b/test/integration/event-handler-test.ts
@@ -131,15 +131,15 @@ test("options.transform", (done) => {
   const eventHandler = createEventHandler({
     transform: (event) => {
       expect(event.id).toBe("123");
       return "funky";
     },
   });
 
-  eventHandler.on("push", (event: EmitterWebhookEvent) => {
+  eventHandler.on("push", (event: string) => {
     expect(event).toBe("funky");
 
     done();