### PR TITLE
fix(typescript): compile-time invalid argument errors

### DIFF
--- a/test/integration/server-test.ts
+++ b/test/integration/server-test.ts
@@ -21,14 +21,9 @@ describe("server-test", () => {
     });
   });
 
-  test("initialised without options", (t) => {
-    try {
-      // @ts-expect-error
-      new Webhooks();
-      t.fail("should throw error");
-    } catch (error) {
-      t();
-    }
+  test("initialised without options", () => {
+    // @ts-expect-error
+    expect(() => new Webhooks()).toThrow();
   });
 
   test("GET /", (t) => {

--- a/test/integration/sign-test.ts
+++ b/test/integration/sign-test.ts
@@ -22,7 +22,8 @@ test("sign(secret) without eventPayload throws", () => {
 
 test("sign({secret, algorithm}) with invalid algorithm throws", () => {
   expect(() =>
-    sign.bind(null, { secret, algorithm: "sha2" as "sha1" }, eventPayload)()
+    // @ts-expect-error
+    sign.bind(null, { secret, algorithm: "sha2" }, eventPayload)()
   ).toThrow();
 });
 

--- a/test/unit/event-handler-on-test.ts
+++ b/test/unit/event-handler-on-test.ts
@@ -1,5 +1,5 @@
 import { receiverOn } from "../../src/event-handler/on";
-import { EmitterWebhookEventName, State } from "../../src/types";
+import { State } from "../../src/types";
 
 function noop() {}
 
@@ -24,17 +24,15 @@ test("receiver.on with invalid event name", () => {
 });
 
 test("receiver.on with event name of '*' throws an error", () => {
-  expect(() =>
-    receiverOn(state, "*" as EmitterWebhookEventName, noop)
-  ).toThrowError(
+  // @ts-expect-error
+  expect(() => receiverOn(state, "*", noop)).toThrowError(
     'Using the "*" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onAny() method instead'
   );
 });
 
 test("receiver.on with event name of 'error' throws an error", () => {
-  expect(() =>
-    receiverOn(state, "error" as EmitterWebhookEventName, noop)
-  ).toThrowError(
+  // @ts-expect-error
+  expect(() => receiverOn(state, "error", noop)).toThrowError(
     'Using the "error" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onError() method instead'
   );
 });

--- a/test/unit/event-handler-on-test.ts
+++ b/test/unit/event-handler-on-test.ts
@@ -25,14 +25,14 @@ test("receiver.on with invalid event name", () => {
 
 test("receiver.on with event name of '*' throws an error", () => {
   // @ts-expect-error
-  expect(() => receiverOn(state, "*", noop)).toThrowError(
+  expect(() => receiverOn(state, "*", noop)).toThrow(
     'Using the "*" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onAny() method instead'
   );
 });
 
 test("receiver.on with event name of 'error' throws an error", () => {
   // @ts-expect-error
-  expect(() => receiverOn(state, "error", noop)).toThrowError(
+  expect(() => receiverOn(state, "error", noop)).toThrow(
     'Using the "error" event with the regular Webhooks.on() function is not supported. Please use the Webhooks.onError() method instead'
   );
 });


### PR DESCRIPTION
This minor change to the test types confirms that an invalid algorithm and the `"*"` and `"error"` event names are compile-time as well as run-time errors, by replacing a couple of type assertions with `// @ts-expect-error` comments. Doesn't touch the implementation, only the tests.

The first commit is a distantly related cosmetic change: replaces a try/catch test with the standard `.toThrow()` matcher. I'm happy to move it out of this PR if you prefer?