### PR TITLE
refactor(typescript): type State#eventHandler

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -15,7 +15,7 @@ import {
 import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 
-interface EventHandler<TTransformed> {
+export interface EventHandler<TTransformed = unknown> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
@@ -26,7 +26,7 @@ interface EventHandler<TTransformed> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>
   ): void;
-  receive(event: EmitterWebhookEvent): Promise<void>;
+  receive(event: EmitterWebhookEvent | Error): Promise<void>;
 }
 
 export function createEventHandler<TTransformed>(

--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -29,7 +29,10 @@ function getHooks(
 }
 
 // main handler function
-export function receiverHandle(state: State, event: EmitterWebhookEvent) {
+export function receiverHandle(
+  state: State,
+  event: EmitterWebhookEvent | Error
+) {
   const errorHandlers = state.hooks.error || [];
 
   if (event instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { createLogger } from "./createLogger";
-import { createEventHandler } from "./event-handler/index";
+import { createEventHandler, EventHandler } from "./event-handler/index";
 import { createMiddleware } from "./middleware/index";
 import { middleware } from "./middleware/middleware";
 import { verifyAndReceive } from "./middleware/verify-and-receive";
@@ -10,6 +10,7 @@ import {
   EmitterWebhookEventName,
   HandlerFunction,
   Options,
+  State,
   WebhookError,
   WebhookEventHandlerError,
 } from "./types";
@@ -44,7 +45,7 @@ class Webhooks<TTransformed> {
       throw new Error("[@octokit/webhooks] options.secret required");
     }
 
-    const state = {
+    const state: State & { eventHandler: EventHandler<TTransformed> } = {
       eventHandler: createEventHandler(options),
       path: options.path || "/",
       secret: options.secret,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import {
   EmitterWebhookEventName,
   HandlerFunction,
   Options,
-  State,
   WebhookError,
   WebhookEventHandlerError,
 } from "./types";
@@ -45,7 +44,7 @@ class Webhooks<TTransformed> {
       throw new Error("[@octokit/webhooks] options.secret required");
     }
 
-    const state: State = {
+    const state = {
       eventHandler: createEventHandler(options),
       path: options.path || "/",
       secret: options.secret,

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -2,14 +2,14 @@ import { debug } from "debug";
 import { createLogger } from "../createLogger";
 import { createEventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
-import { Options, State } from "../types";
+import { Options } from "../types";
 
 export function createMiddleware(options: Options) {
   if (!options || !options.secret) {
     throw new Error("[@octokit/webhooks] options.secret required");
   }
 
-  const state: State = {
+  const state = {
     eventHandler: createEventHandler(options),
     path: options.path || "/",
     secret: options.secret,

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,15 +1,15 @@
 import { debug } from "debug";
 import { createLogger } from "../createLogger";
-import { createEventHandler } from "../event-handler/index";
+import { createEventHandler, EventHandler } from "../event-handler/index";
 import { middleware } from "./middleware";
-import { Options } from "../types";
+import { Options, State } from "../types";
 
 export function createMiddleware(options: Options) {
   if (!options || !options.secret) {
     throw new Error("[@octokit/webhooks] options.secret required");
   }
 
-  const state = {
+  const state: State & { eventHandler: EventHandler } = {
     eventHandler: createEventHandler(options),
     path: options.path || "/",
     secret: options.secret,

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -1,4 +1,5 @@
 import { WebhookEventName } from "@octokit/webhooks-definitions/schema";
+import { EventHandler } from "../event-handler";
 import { isntWebhook } from "./isnt-webhook";
 import { getMissingHeaders } from "./get-missing-headers";
 import { getPayload } from "./get-payload";
@@ -7,7 +8,7 @@ import { IncomingMessage, ServerResponse } from "http";
 import { State, WebhookEventHandlerError } from "../types";
 
 export function middleware(
-  state: State,
+  state: State & { eventHandler: EventHandler },
   request: IncomingMessage,
   response: ServerResponse,
   next?: Function

--- a/src/middleware/verify-and-receive.ts
+++ b/src/middleware/verify-and-receive.ts
@@ -1,8 +1,9 @@
+import { EventHandler } from "../event-handler";
 import { EmitterWebhookEvent, State } from "../types";
 import { verify } from "../verify/index";
 
 export function verifyAndReceive(
-  state: State,
+  state: State & { eventHandler: EventHandler },
   event: EmitterWebhookEvent & { signature: string }
 ): any {
   // verify will validate that the secret is not undefined
@@ -26,5 +27,5 @@ export function verifyAndReceive(
     id: event.id,
     name: event.name,
     payload: event.payload,
-  });
+  } as EmitterWebhookEvent);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type {
   WebhookEventName,
 } from "@octokit/webhooks-definitions/schema";
 import { Logger } from "./createLogger";
+import { EventHandler } from "./event-handler";
 import type { emitterEventNames } from "./generated/webhook-names";
 
 export type EmitterWebhookEventName = typeof emitterEventNames[number];
@@ -40,7 +41,7 @@ type Hooks = {
 };
 
 export interface State extends Options<any> {
-  eventHandler?: any;
+  eventHandler?: EventHandler;
   hooks: Hooks;
   log: Logger;
 }

--- a/test/unit/middleware-test.ts
+++ b/test/unit/middleware-test.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage, ServerResponse } from "http";
+import { EventHandler } from "../../src/event-handler";
 import { middleware } from "../../src/middleware/middleware";
 import { getPayload } from "../../src/middleware/get-payload";
 import { verifyAndReceive } from "../../src/middleware/verify-and-receive";
@@ -20,6 +21,7 @@ test("next() callback", () => {
 
   middleware(
     {
+      eventHandler: (undefined as unknown) as EventHandler,
       hooks: {},
       log: console,
     },
@@ -45,7 +47,12 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockResolvedValueOnce(undefined);
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo", log: console },
+      {
+        eventHandler: (undefined as unknown) as EventHandler,
+        hooks: {},
+        path: "/foo",
+        log: console,
+      },
       ({
         method: "POST",
         url: "/foo",
@@ -78,7 +85,12 @@ describe("when does a timeout on retrieving the payload", () => {
     mockVerifyAndReceive.mockRejectedValueOnce(new Error("random error"));
 
     const promiseMiddleware = middleware(
-      { hooks: {}, path: "/foo", log: console },
+      {
+        eventHandler: (undefined as unknown) as EventHandler,
+        hooks: {},
+        path: "/foo",
+        log: console,
+      },
       ({
         method: "POST",
         url: "/foo",


### PR DESCRIPTION
What do you think about changing `State#eventHandler` from `any` to `EventHandler`? I don't think this affects the external types, just makes the internal types more accurate.
```Diff
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +41,7 @@ type Hooks = {
 };
 
 export interface State extends Options<any> {
-  eventHandler?: any;
+  eventHandler?: EventHandler;
   hooks: Hooks;
   log: Logger;
 }