### PR TITLE
ci: fix `@octokit/webhooks-definitions` updater

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - run: npm ci
-      - run: npm install --save-dev --save-exact @octokit/webhooks-definitions@latest
+      - run: npm install --save-exact @octokit/webhooks-definitions@latest
       - run: npm run generate-types
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
Remove the `--save-dev` flag as `@octokit/webhooks-definitions` is now a production dependency as of v8