### PR TITLE
ci(update): await `@octokit/webhooks-definitions` package version to be published to npm before downloading it from the registry

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,6 +12,10 @@ jobs:
       - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm install --save-exact @octokit/webhooks-definitions@latest
+      - uses: gr2m/await-npm-package-version-action@v1
+        with:
+          package: "@octokit/webhooks-definitions"
+          version: ${{ github.event.client_payload.release.tag_name }}
       - run: npm run generate-types
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
Fixes #470