### PR TITLE
ci(update): move the install of @octokit/webhooks-definitions to after the wait action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,11 +11,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - run: npm ci
-      - run: npm install --save-exact @octokit/webhooks-definitions@latest
       - uses: gr2m/await-npm-package-version-action@v1
         with:
           package: "@octokit/webhooks-definitions"
           version: ${{ github.event.client_payload.release.tag_name }}
+      - run: npm install --save-exact @octokit/webhooks-definitions@latest
       - run: npm run generate-types
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
Ref: https://github.com/octokit/webhooks.js/pull/472#discussion_r576494296