### PR TITLE
Explicitly specify that TS 4.1 is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "semantic-release": "^17.0.0",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.0.2"
+    "typescript": "^4.1.5"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The compilation under TypeScript 4.0 fails.

```
$ npm install typescript@4.0
$ npm run validate:ts


> @octokit/webhooks@0.0.0-development validate:ts /Users/honza/projects/webhooks.js
> tsc --noEmit --noImplicitAny --target es2020 --esModuleInterop --moduleResolution node test/typescript-validate.ts

src/types.ts:12:27 - error TS1110: Type expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                             ~~~

src/types.ts:12:36 - error TS1005: '}' expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                                      ~~~~~~~~~~~~~

src/types.ts:12:49 - error TS1128: Declaration or statement expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                                                   ~

src/types.ts:12:50 - error TS1128: Declaration or statement expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                                                    ~

src/types.ts:12:52 - error TS1005: ';' expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                                                      ~

src/types.ts:12:59 - error TS1005: ';' expected.

12 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
                                                             ~~~~~~~

src/types.ts:53:55 - error TS1005: ';' expected.

53  * Error object with optional properties coming from `octokit.request` errors
                                                         ~~~~~~~

src/types.ts:77:1 - error TS1160: Unterminated template literal.

77



Found 8 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @octokit/webhooks@0.0.0-development validate:ts: `tsc --noEmit --noImplicitAny --target es2020 --esModuleInterop --moduleResolution node test/typescript-validate.ts`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the @octokit/webhooks@0.0.0-development validate:ts script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

```

I am not sure if the `package-json.lock` should be modified as well or not. I have modified it to match the minimum required version and therefore make the continuous integration run on that version, which is IMO an advantage.