### PR TITLE
fix(typescript): revert #459 & #464

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -30,7 +30,7 @@ interface EventHandler<TTransformed> {
 }
 
 export function createEventHandler<TTransformed>(
-  options: Options<any, TTransformed>
+  options: Options<TTransformed>
 ): EventHandler<TTransformed> {
   const state: State = {
     hooks: {},

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -30,7 +30,7 @@ interface EventHandler<TTransformed> {
 }
 
 export function createEventHandler<TTransformed>(
-  options?: Options<TTransformed>
+  options: Options<any, TTransformed>
 ): EventHandler<TTransformed> {
   const state: State = {
     hooks: {},

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -15,23 +15,23 @@ import {
 import { receiverHandle as receive } from "./receive";
 import { removeListener } from "./remove-listener";
 
-interface EventHandler<T extends Options> {
+interface EventHandler<TTransformed> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, T["transform"]>
+    callback: HandlerFunction<E, TTransformed>
   ): void;
   onAny(handler: (event: EmitterWebhookEvent) => any): void;
   onError(handler: (event: WebhookEventHandlerError) => any): void;
   removeListener<E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, T["transform"]>
+    callback: HandlerFunction<E, TTransformed>
   ): void;
   receive(event: EmitterWebhookEvent): Promise<void>;
 }
 
-export function createEventHandler<T extends Options>(
-  options?: T
-): EventHandler<T> {
+export function createEventHandler<TTransformed>(
+  options?: Options<TTransformed>
+): EventHandler<TTransformed> {
   const state: State = {
     hooks: {},
     log: createLogger(options && options.log),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,18 +17,18 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<T extends Options> {
+class Webhooks<TTransformed> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, T["transform"]>
+    callback: HandlerFunction<E, TTransformed>
   ) => void;
   public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
   public removeListener: <E extends EmitterWebhookEventName>(
     event: E | E[],
-    callback: HandlerFunction<E, T["transform"]>
+    callback: HandlerFunction<E, TTransformed>
   ) => void;
   public receive: (event: EmitterWebhookEvent) => Promise<void>;
   public middleware: (
@@ -40,7 +40,7 @@ class Webhooks<T extends Options> {
     options: EmitterWebhookEvent & { signature: string }
   ) => Promise<void>;
 
-  constructor(options: T) {
+  constructor(options: Options<TTransformed>) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,12 +32,8 @@ type TransformMethod<T> = (event: EmitterWebhookEvent) => T | PromiseLike<T>;
 
 export type HandlerFunction<
   TName extends EmitterWebhookEventName,
-  TTransform
-> = (
-  event: TTransform extends TransformMethod<infer T>
-    ? T
-    : EmitterWebhookEvent<TName>
-) => any;
+  TTransformed
+> = (event: EmitterWebhookEvent<TName> & TTransformed) => any;
 
 type Hooks = {
   [key: string]: Function[];

--- a/test/integration/event-handler-test.ts
+++ b/test/integration/event-handler-test.ts
@@ -135,7 +135,7 @@ test("options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: string) => {
+  eventHandler.on("push", (event: EmitterWebhookEvent) => {
     expect(event).toBe("funky");
 
     done();
@@ -155,7 +155,7 @@ test("async options.transform", (done) => {
     },
   });
 
-  eventHandler.on("push", (event: string) => {
+  eventHandler.on("push", (event: EmitterWebhookEvent) => {
     expect(event).toBe("funky");
     done();
   });

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -72,6 +72,10 @@ export default async function () {
   const webhooks = new Webhooks({
     secret: "blah",
     path: "/webhooks",
+    transform: (event) => {
+      console.log(event.payload);
+      return Object.assign(event, { foo: "bar" });
+    },
   });
 
   // Check named exports of new API work
@@ -163,17 +167,6 @@ export default async function () {
 
   webhooks.on("issues", (event) => {
     console.log(event.payload.issue);
-  });
-}
-
-{
-  const webhooks = new Webhooks({
-    secret: "blah",
-    path: "/webhooks",
-    transform: (event) => {
-      console.log(event.payload);
-      return Object.assign(event, { foo: "bar" });
-    },
   });
 
   webhooks.on("issues", (event) => {

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -166,6 +166,7 @@ export default async function () {
   });
 
   webhooks.on("issues", (event) => {
+    // ⚠️ This test is for assuring 'transform' method is preserving event.payload
     console.log(event.payload.issue);
   });
 


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Reverts the following PR's: 
* https://github.com/octokit/webhooks.js/pull/464
* https://github.com/octokit/webhooks.js/pull/459

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Types for webhooks are broken when a `transform` function is passed in the options: 
https://github.com/octokit/app.js/pull/213#issuecomment-798928569

Follow up conversation:
https://github.com/octokit/webhooks.js/pull/492#issuecomment-798938503