### PR TITLE
ci: update PR body text to reflect npm package name

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.OCTOKITBOT_PAT }}"
         with:
           title: "\U0001F6A7 \U0001F916\U0001F4EF Webhooks changed"
-          body: "A new release of [@octokit/webhooks](https://github.com/octokit/webhooks) was just released \U0001F44B\U0001F916\n\nThis pull request updates the TypeScript definitions derived from `@octokit/webhooks`. I can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
+          body: "A new release of [@octokit/webhooks-definitions](https://github.com/octokit/webhooks) was just released \U0001F44B\U0001F916\n\nThis pull request updates the TypeScript definitions derived from `@octokit/webhooks-definitions`. I can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
           branch: "update-octokit-webhooks"
           author: Octokit Bot <octokitbot@martynus.net>
           commit-message: "WIP: Webhooks changed - please review"


### PR DESCRIPTION
Small change to the body text to use the npm package name instead of `@octokit/webhooks` which could lead to confusion between the npm package published from this repo and `@octokit/webhooks-definitions`