### PR TITLE
fix(typescript): default `TTransformed` in `Webhooks` type parameter to `unknown`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
 import { verify } from "./verify/index";
 
 // U holds the return value of `transform` function in Options
-class Webhooks<TTransformed> {
+class Webhooks<TTransformed = unknown> {
   public sign: (payload: string | object) => string;
   public verify: (eventPayload: string | object, signature: string) => boolean;
   public on: <E extends EmitterWebhookEventName>(


### PR DESCRIPTION
addresses https://github.com/octokit/webhooks.js/pull/509#discussion_r602791280 @G-Rath @wolfy1339
