### PR TITLE
fix: "Unknown route: POST /"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ webhooks.onAny(({ id, name, payload }) => {
   console.log(name, "event received");
 });
 
-require("http").createServer(createNodeMiddleware(webhooks)).listen(3000);
+require("http").createServer(createNodeMiddleware(webhooks, { path: "/" })).listen(3000);
 // can now receive webhook events at /api/github/webhooks
 ```
 


### PR DESCRIPTION
If just omit the options as in the example, the server will return GitHub this error for any webhooks: [404] "Unknown route: POST /"

![2021-03-30_235511](https://user-images.githubusercontent.com/8125593/113059263-eb709a00-91b7-11eb-81bd-44bb911c0745.png)

-----
[View rendered README.md](https://github.com/Jmopel/webhooks.js/blob/patch-1/README.md)