### PR TITLE
fix(types): allow `IncomingMessage` to have bodies of other types

### DIFF
--- a/src/middleware-legacy/get-payload.ts
+++ b/src/middleware-legacy/get-payload.ts
@@ -5,7 +5,7 @@ import { IncomingMessage } from "http";
 
 declare module "http" {
   interface IncomingMessage {
-    body?: WebhookEvent;
+    body?: WebhookEvent | unknown;
   }
 }
 
@@ -13,7 +13,7 @@ export function getPayload(request: IncomingMessage): Promise<WebhookEvent> {
   // If request.body already exists we can stop here
   // See https://github.com/octokit/webhooks.js/pull/23
 
-  if (request.body) return Promise.resolve(request.body);
+  if (request.body) return Promise.resolve(request.body as WebhookEvent);
 
   return new Promise((resolve, reject) => {
     let data = "";

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -5,7 +5,7 @@ import { IncomingMessage } from "http";
 
 declare module "http" {
   interface IncomingMessage {
-    body?: WebhookEvent;
+    body?: WebhookEvent | unknown;
   }
 }
 
@@ -13,7 +13,7 @@ export function getPayload(request: IncomingMessage): Promise<WebhookEvent> {
   // If request.body already exists we can stop here
   // See https://github.com/octokit/webhooks.js/pull/23
 
-  if (request.body) return Promise.resolve(request.body);
+  if (request.body) return Promise.resolve(request.body as WebhookEvent);
 
   return new Promise((resolve, reject) => {
     let data = "";


### PR DESCRIPTION
This is more accurate, as we don't actually know for sure that `body` will be our type; this also should stop conflicts with other packages that do this.