### PR TITLE
docs: add references about why we use `crypto.timingSafeEqual`

### DIFF
--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -28,5 +28,8 @@ export function verify(
     return false;
   }
 
+  // constant time comparison to prevent timing attachs
+  // https://stackoverflow.com/a/31096242/206879
+  // https://en.wikipedia.org/wiki/Timing_attack
   return timingSafeEqual(signatureBuffer, verificationBuffer);
 }


### PR DESCRIPTION
follow up to https://github.com/octokit/webhooks.js/issues/475#issuecomment-812227414 @wolfy1339
