### PR TITLE
fix: pass on to the next middleware in case of express

### DIFF
--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(
   const isExpressMiddleware = typeof next === "function";
   if (isUnknownRoute) {
     if (isExpressMiddleware) {
-      return next();
+      return next && next();
     } else {
       return options.onUnhandledRequest(request, response);
     }

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -23,8 +23,12 @@ export async function middleware(
 
   const isUnknownRoute = request.method !== "POST" || pathname !== options.path;
   const isExpressMiddleware = typeof next === "function";
-  if (!isExpressMiddleware && isUnknownRoute) {
-    return options.onUnhandledRequest(request, response);
+  if (isUnknownRoute) {
+    if (isExpressMiddleware) {
+      return next();
+    } else {
+      return options.onUnhandledRequest(request, response);
+    }
   }
 
   const missingHeaders = getMissingHeaders(request).join(", ");

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(
   const isExpressMiddleware = typeof next === "function";
   if (isUnknownRoute) {
     if (isExpressMiddleware) {
-      return next && next();
+      return next!();
     } else {
       return options.onUnhandledRequest(request, response);
     }

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -385,6 +385,7 @@ describe("createNodeMiddleware(webhooks)", () => {
       body: JSON.stringify(pushEventPayload),
     });
 
+    await expect(response.text()).resolves.toContain("Cannot POST /test");
     expect(response.status).toEqual(404);
 
     server.close();

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -331,13 +331,71 @@ describe("createNodeMiddleware(webhooks)", () => {
     expect(response.status).toEqual(202);
   });
 
-  test("express middleware 404", async () => {
+  test("express middleware no mount path 404", async () => {
     const app = express();
     const webhooks = new Webhooks({
       secret: "mySecret",
     });
 
-    app.post("/test", createNodeMiddleware(webhooks));
+    app.use(createNodeMiddleware(webhooks));
+    app.all("*", (_request: any, response: any) =>
+      response.status(404).send("Dafuq")
+    );
+
+    const server = app.listen();
+
+    const { port } = server.address();
+
+    const response = await fetch(`http://localhost:${port}/test`, {
+      method: "POST",
+      body: JSON.stringify(pushEventPayload),
+    });
+
+    await expect(response.text()).resolves.toBe("Dafuq");
+    expect(response.status).toEqual(404);
+
+    server.close();
+  });
+
+  test("express middleware no mount path no next", async () => {
+    const app = express();
+    const webhooks = new Webhooks({
+      secret: "mySecret",
+    });
+
+    app.all("/foo", (_request: any, response: any) => response.end("ok\n"));
+    app.use(createNodeMiddleware(webhooks));
+
+    const server = app.listen();
+
+    const { port } = server.address();
+
+    const response = await fetch(`http://localhost:${port}/test`, {
+      method: "POST",
+      body: JSON.stringify(pushEventPayload),
+    });
+
+    await expect(response.text()).resolves.toContain("Cannot POST /test");
+    expect(response.status).toEqual(404);
+
+    const responseForFoo = await fetch(`http://localhost:${port}/foo`, {
+      method: "POST",
+      body: JSON.stringify(pushEventPayload),
+    });
+
+    await expect(responseForFoo.text()).resolves.toContain("ok\n");
+    expect(responseForFoo.status).toEqual(200);
+
+    server.close();
+  });
+
+  test("express middleware no mount path with options.path", async () => {
+    const app = express();
+    const webhooks = new Webhooks({
+      secret: "mySecret",
+    });
+
+    app.use(createNodeMiddleware(webhooks, { path: "/test" }));
     app.all("*", (_request: any, response: any) =>
       response.status(404).send("Dafuq")
     );
@@ -356,42 +414,13 @@ describe("createNodeMiddleware(webhooks)", () => {
       body: JSON.stringify(pushEventPayload),
     });
 
-    await expect(response.text()).resolves.toBe("Dafuq");
-    expect(response.status).toEqual(404);
+    await expect(response.text()).resolves.toBe("ok\n");
+    expect(response.status).toEqual(200);
 
     server.close();
   });
 
-  test("express middleware no next", async () => {
-    const app = express();
-    const webhooks = new Webhooks({
-      secret: "mySecret",
-    });
-
-    app.all("/foo", (_request: any, response: any) => response.end("ok\n"));
-    app.post("/test", createNodeMiddleware(webhooks));
-
-    const server = app.listen();
-
-    const { port } = server.address();
-
-    const response = await fetch(`http://localhost:${port}/test`, {
-      method: "POST",
-      headers: {
-        "X-GitHub-Delivery": "123e4567-e89b-12d3-a456-426655440000",
-        "X-GitHub-Event": "push",
-        "X-Hub-Signature-256": signatureSha256,
-      },
-      body: JSON.stringify(pushEventPayload),
-    });
-
-    await expect(response.text()).resolves.toContain("Cannot POST /test");
-    expect(response.status).toEqual(404);
-
-    server.close();
-  });
-
-  test("express middleware match options.path", async () => {
+  test("express middleware with mount path with options.path", async () => {
     const app = express();
     const webhooks = new Webhooks({
       secret: "mySecret",


### PR DESCRIPTION
As I explained [here](https://github.com/octokit/webhooks.js/pull/509#issuecomment-811379891), it is now required to always install this middleware to the end of the chain, otherwise it rejects all requests it cannot handle.