### PR TITLE
feat: update package to use new packages split from `@octokit/webhooks-defintions`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,9 +13,14 @@ jobs:
       - run: npm ci
       - uses: gr2m/await-npm-package-version-action@v1
         with:
-          package: "@octokit/webhooks-definitions"
+          package: "@octokit/webhooks-schemas"
           version: ${{ github.event.client_payload.release.tag_name }}
-      - run: npm install --save-exact @octokit/webhooks-definitions@latest
+      - run: npm install --save-exact --save-dev @octokit/webhooks-schemas@latest
+      - uses: gr2m/await-npm-package-version-action@v1
+        with:
+          package: "@octokit/webhooks-types"
+          version: ${{ github.event.client_payload.release.tag_name }}
+      - run: npm install --save-exact @octokit/webhooks-types@latest
       - run: npm run generate-types
       - name: create pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -1625,15 +1625,21 @@
         "@octokit/openapi-types": "^6.0.0"
       }
     },
-    "@octokit/webhooks-definitions": {
-      "version": "3.67.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz",
-      "integrity": "sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA=="
-    },
     "@octokit/webhooks-methods": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-1.0.0.tgz",
       "integrity": "sha512-pVceMQcj9SZ5p2RkemL0TuuPdGULNQj9F3Pq1cNM1xH+Kst1VNt0dj3PEGZRZV473njrDnYdi/OG4wWY9TLbbA=="
+    },
+    "@octokit/webhooks-schemas": {
+      "version": "3.69.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-schemas/-/webhooks-schemas-3.69.0.tgz",
+      "integrity": "sha512-k7fnF77owyDjani+o7bwD1Gusayy4k97bpXoa0dYyt1pdwUdrgK6E2wFe1reB10rNUN+3QVd//eE49qBPUgnRA==",
+      "dev": true
+    },
+    "@octokit/webhooks-types": {
+      "version": "3.69.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-3.69.0.tgz",
+      "integrity": "sha512-TMOAb9KswEYrPBA/A/EmscviRxUz+nmCNEFTviQhAR5fxS9V5UE/lIVvrsXyMlUPt8/Rrdk9WFyF6FFwthtdXg=="
     },
     "@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
   "prettier": {},
   "dependencies": {
     "@octokit/request-error": "^2.0.2",
-    "@octokit/webhooks-definitions": "3.67.3",
     "@octokit/webhooks-methods": "^1.0.0",
+    "@octokit/webhooks-types": "3.69.0",
     "aggregate-error": "^3.1.0"
   },
   "devDependencies": {
     "@jest/types": "^26.6.2",
     "@octokit/tsconfig": "^1.0.1",
+    "@octokit/webhooks-schemas": "3.69.0",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-node": "^0.9.2",
     "@pika/plugin-build-web": "^0.9.2",

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -12,7 +12,7 @@ interface Schema extends JSONSchema7 {
   oneOf: JSONSchemaWithRef[];
 }
 
-const schema = require("@octokit/webhooks-definitions/schema.json") as Schema;
+const schema = require("@octokit/webhooks-schemas") as Schema;
 
 const guessAtEventName = (name: string) => {
   const [, eventName] = /^(.+)[$_-]event/u.exec(name) ?? [];

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -1,4 +1,4 @@
-import { WebhookEvent } from "@octokit/webhooks-definitions/schema";
+import { WebhookEvent } from "@octokit/webhooks-types";
 // @ts-ignore to address #245
 import AggregateError from "aggregate-error";
 

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -4,7 +4,7 @@
 type IncomingMessage = any;
 type ServerResponse = any;
 
-import { WebhookEventName } from "@octokit/webhooks-definitions/schema";
+import { WebhookEventName } from "@octokit/webhooks-types";
 
 import { Webhooks } from "../../index";
 import { WebhookEventHandlerError } from "../../types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { RequestError } from "@octokit/request-error";
 import type {
   WebhookEventMap,
   WebhookEventName,
-} from "@octokit/webhooks-definitions/schema";
+} from "@octokit/webhooks-types";
 import { Logger } from "./createLogger";
 import type { emitterEventNames } from "./generated/webhook-names";
 

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -2,7 +2,7 @@ import {
   InstallationCreatedEvent,
   InstallationDeletedEvent,
   PushEvent,
-} from "@octokit/webhooks-definitions/schema";
+} from "@octokit/webhooks-types";
 import pushEvent from "./push-payload.json";
 import installationCreatedEvent from "./installation-created-payload.json";
 import installationDeletedEvent from "./installation-deleted-payload.json";


### PR DESCRIPTION
I updated the package to use the newly published packages that were split from `@octokit/webhooks-definitions`.

`@octokit/webhooks-schemas` was placed in `devDependencies` as it is not used in thew local package.
`@octokit/webhooks-types` was added in `dependencies` as it is used in published code.