### PR TITLE
ci: Add NodeJS 16 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           - 10
           - 12
           - 14
+          - 16
     name: Node ${{ matrix.node }} 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
NodeJS 16 was just released today.
It will be the next LTS version when v10 is EOL'd later this month.