### PR TITLE
feat: drop NodeJS v10, v12 support + test NodeJS v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 10
           - 12
           - 14
           - 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         node:
           - 14
           - 16
+          - 18
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12
           - 14
           - 16
     name: Node ${{ matrix.node }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "ts-jest": "^27.0.0",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "ts-node": "^10.0.0",
     "typescript": "^4.1.5"
   },
+  "engines": {
+    "node": ">= 12"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -55,7 +58,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "12"
+        }
       ],
       [
         "@pika/plugin-build-web"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.1.5"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "publishConfig": {
     "access": "public"
@@ -60,7 +60,7 @@
       [
         "@pika/plugin-build-node",
         {
-          "minNodeVersion": "12"
+          "minNodeVersion": "14"
         }
       ],
       [


### PR DESCRIPTION
BREAKING CHANGE: drop support for NodeJS <= 14