### PR TITLE
docs(README): `@octokit/webhooks-types` is now the source module for TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ If there are actions for a webhook, events are emitted for both, the webhook nam
 
 ## TypeScript
 
-The types for the webhook payloads are sourced from `@octokit/webhooks-definitions`,
+The types for the webhook payloads are sourced from [`@octokit/webhooks-types`](https://github.com/octokit/webhooks/tree/master/payload-types),
 which can be used by themselves.
 
 In addition to these types, `@octokit/webhooks` exports 2 types specific to itself:


### PR DESCRIPTION
closes #446

-----
[View rendered README.md](https://github.com/octokit/webhooks.js/blob/gr2m-patch-1/README.md)