### PR TITLE
feat:`octokit.verifyAndReceive()` accepts raw string payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ webhooks.verifyAndReceive({ id, name, payload, signature });
           payload
         </code>
         <em>
-          Object
+          Object or String
         </em>
       </td>
       <td>

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ webhooks.verify(eventPayload, signature);
           eventPayload
         </code>
         <em>
-          (Object)
+          (Object or String)
         </em>
       </td>
       <td>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import {
   State,
   WebhookError,
   WebhookEventHandlerError,
+  EmitterWebhookEventWithStringPayloadAndSignature,
+  EmitterWebhookEventWithSignature,
 } from "./types";
 
 export { createNodeMiddleware } from "./middleware/node/index";
@@ -34,7 +36,9 @@ class Webhooks<TTransformed = unknown> {
   ) => void;
   public receive: (event: EmitterWebhookEvent) => Promise<void>;
   public verifyAndReceive: (
-    options: EmitterWebhookEvent & { signature: string }
+    options:
+      | EmitterWebhookEventWithStringPayloadAndSignature
+      | EmitterWebhookEventWithSignature
   ) => Promise<void>;
 
   constructor(options: Options<TTransformed> & { secret: string }) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,17 @@ export type EmitterWebhookEvent<
     }
   : BaseWebhookEvent<Extract<TEmitterEvent, WebhookEventName>>;
 
+export type EmitterWebhookEventWithStringPayloadAndSignature = {
+  id: string;
+  name: EmitterWebhookEventName;
+  payload: string;
+  signature: string;
+};
+
+export type EmitterWebhookEventWithSignature = EmitterWebhookEvent & {
+  signature: string;
+};
+
 interface BaseWebhookEvent<TName extends WebhookEventName> {
   id: string;
   name: TName;

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,10 +1,16 @@
 import { verify } from "@octokit/webhooks-methods";
 
-import { EmitterWebhookEvent, State } from "./types";
+import {
+  EmitterWebhookEventWithStringPayloadAndSignature,
+  EmitterWebhookEventWithSignature,
+  State,
+} from "./types";
 
 export async function verifyAndReceive(
   state: State & { secret: string },
-  event: EmitterWebhookEvent & { signature: string }
+  event:
+    | EmitterWebhookEventWithStringPayloadAndSignature
+    | EmitterWebhookEventWithSignature
 ): Promise<any> {
   // verify will validate that the secret is not undefined
   const matchesSignature = await verify(
@@ -26,6 +32,9 @@ export async function verifyAndReceive(
   return state.eventHandler.receive({
     id: event.id,
     name: event.name,
-    payload: event.payload,
+    payload:
+      typeof event.payload === "string"
+        ? JSON.parse(event.payload)
+        : event.payload,
   });
 }


### PR DESCRIPTION
fixes #420


-----
[View rendered README.md](https://github.com/octokit/webhooks.js/blob/420/verifyAndReceive-with-string-payload/README.md)