### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,13 @@ jobs:
           - 12
           - 14
           - 16
-    name: Node ${{ matrix.node }} 
+    name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm test
 
@@ -34,5 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          cache: npm
       - run: npm ci
       - run: "npm run validate:ts"

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           version: 12
+          cache: npm
       - run: npm ci
       - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          cache: npm
       - run: npm ci
       - uses: gr2m/await-npm-package-version-action@v1
         with:
@@ -27,8 +29,19 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.OCTOKITBOT_PAT }}"
         with:
-          title: "\U0001F6A7 \U0001F916\U0001F4EF Webhooks changed"
-          body: "A new release of [@octokit/webhooks-definitions](https://github.com/octokit/webhooks) was just released \U0001F44B\U0001F916\n\nThis pull request updates the TypeScript definitions derived from `@octokit/webhooks-definitions`. I can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
+          title: "🚧 🤖📯 Webhooks changed"
+          body: "A new release of
+            [@octokit/webhooks-definitions](https://github.com/octokit/webhooks)
+            was just released 👋🤖
+
+
+            This pull request updates the TypeScript definitions
+            derived from `@octokit/webhooks-definitions`. I can't tell if the
+            changes are fixes, features or breaking, you'll have to figure that
+            out on yourself and adapt the commit messages accordingly to trigger
+            the right release, see [our commit message
+            conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUT\
+            ING.md#merging-the-pull-request--releasing-a-new-version).\n"
           branch: "update-octokit-webhooks"
           author: Octokit Bot <octokitbot@martynus.net>
           commit-message: "WIP: Webhooks changed - please review"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,19 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.OCTOKITBOT_PAT }}"
         with:
-          title: "🚧 🤖📯 Webhooks changed"
-          body: "A new release of
-            [@octokit/webhooks-definitions](https://github.com/octokit/webhooks)
-            was just released 👋🤖
-
-
-            This pull request updates the TypeScript definitions
-            derived from `@octokit/webhooks-definitions`. I can't tell if the
-            changes are fixes, features or breaking, you'll have to figure that
-            out on yourself and adapt the commit messages accordingly to trigger
-            the right release, see [our commit message
-            conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUT\
-            ING.md#merging-the-pull-request--releasing-a-new-version).\n"
+          title: "\U0001F6A7 \U0001F916\U0001F4EF Webhooks changed"
+          body: "A new release of [@octokit/webhooks-definitions](https://github.com/octokit/webhooks) was just released \U0001F44B\U0001F916\n\nThis pull request updates the TypeScript definitions derived from `@octokit/webhooks-definitions`. I can't tell if the changes are fixes, features or breaking, you'll have to figure that out on yourself and adapt the commit messages accordingly to trigger the right release, see [our commit message conventions](https://github.com/octokit/openapi/blob/main/CONTRIBUTING.md#merging-the-pull-request--releasing-a-new-version).\n"
           branch: "update-octokit-webhooks"
           author: Octokit Bot <octokitbot@martynus.net>
           commit-message: "WIP: Webhooks changed - please review"


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
