### PR TITLE
fix(types): Add ability to remove onAny listeners again

### DIFF
--- a/src/event-handler/remove-listener.ts
+++ b/src/event-handler/remove-listener.ts
@@ -2,7 +2,7 @@ import { EmitterWebhookEventName, State } from "../types";
 
 export function removeListener(
   state: State,
-  webhookNameOrNames: EmitterWebhookEventName | EmitterWebhookEventName[],
+  webhookNameOrNames: "*" | EmitterWebhookEventName | EmitterWebhookEventName[],
   handler: Function
 ) {
   if (Array.isArray(webhookNameOrNames)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
   HandlerFunction,
+  RemoveHandlerFunction,
   Options,
   State,
   WebhookError,
@@ -31,9 +32,9 @@ class Webhooks<TTransformed = unknown> {
   ) => void;
   public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
   public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
-  public removeListener: <E extends EmitterWebhookEventName>(
+  public removeListener: <E extends EmitterWebhookEventName | "*">(
     event: E | E[],
-    callback: HandlerFunction<E, TTransformed>
+    callback: RemoveHandlerFunction<E, TTransformed>
   ) => void;
   public receive: (event: EmitterWebhookEvent) => Promise<void>;
   public verifyAndReceive: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export type HandlerFunction<
   TTransformed
 > = (event: EmitterWebhookEvent<TName> & TTransformed) => any;
 
+export type RemoveHandlerFunction<
+  TName extends EmitterWebhookEventName | "*",
+  TTransformed
+> = (event: EmitterWebhookEvent<Exclude<TName, "*">> & TTransformed) => any;
+
 type Hooks = {
   [key: string]: Function[];
 };

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -6,7 +6,11 @@ import {
   createNodeMiddleware,
 } from "../src/index";
 import { createServer } from "http";
-import { HandlerFunction, EmitterWebhookEventName } from "../src/types";
+import {
+  HandlerFunction,
+  RemoveHandlerFunction,
+  EmitterWebhookEventName,
+} from "../src/types";
 
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS FOR TYPECHECKING ONLY
@@ -117,6 +121,12 @@ export default async function () {
 
   webhooks.on("check_run.created", () => {
     return Promise.resolve(10);
+  });
+
+  webhooks.removeListener("*", async ({ id, name, payload }) => {
+    console.log(name, "event received", id);
+    const sig = await webhooks.sign(payload);
+    webhooks.verify(payload, sig);
   });
 
   webhooks.removeListener("check_run.created", ({ name, payload }) => {


### PR DESCRIPTION
- Attempt a fix for https://github.com/octokit/webhooks.js/issues/622 that doesn't blow up the type checking duration.
- A few key differences from the original PR at: https://github.com/octokit/webhooks.js/issues/622 (I've commented in the diff where these differ)