### PR TITLE
Middleware changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const webhooks = new Webhooks({
   secret: "mysecret",
 });
 
-webhooks.onAny(({ id, name, payload }) => {
+webhooks.onAny(({ id, name, payload, extraData }) => {
   console.log(name, "event received");
 });
 
@@ -223,7 +223,7 @@ The `verify` method can be imported as static method from [`@octokit/webhooks-me
 ### webhooks.verifyAndReceive()
 
 ```js
-webhooks.verifyAndReceive({ id, name, payload, signature });
+webhooks.verifyAndReceive({ id, name, payload, extraData, signature });
 ```
 
 <table width="100%">
@@ -316,7 +316,7 @@ eventHandler
 ### webhooks.receive()
 
 ```js
-webhooks.receive({ id, name, payload });
+webhooks.receive({ id, name, payload, extraData });
 ```
 
 <table width="100%">
@@ -370,6 +370,8 @@ Returns a promise. Runs all handlers set with [`webhooks.on()`](#webhookson) in 
 
 The `.receive()` method belongs to the `event-handler` module which can be used [standalone](src/event-handler/).
 
+The `extraData` is an optional parameter, if it is set, it will be available in the `on` functions.
+
 ### webhooks.on()
 
 ```js
@@ -420,7 +422,7 @@ webhooks.on(eventNames, handler);
         <strong>Required.</strong>
         Method to be run each time the event with the passed name is received.
         the <code>handler</code> function can be an async function, throw an error or
-        return a Promise. The handler is called with an event object: <code>{id, name, payload}</code>.
+        return a Promise. The handler is called with an event object: <code>{id, name, payload, extraData}</code>.
       </td>
     </tr>
   </tbody>
@@ -449,7 +451,7 @@ webhooks.onAny(handler);
         <strong>Required.</strong>
         Method to be run each time any event is received.
         the <code>handler</code> function can be an async function, throw an error or
-        return a Promise. The handler is called with an event object: <code>{id, name, payload}</code>.
+        return a Promise. The handler is called with an event object: <code>{id, name, payload, extraData}</code>.
       </td>
     </tr>
   </tbody>
@@ -482,7 +484,7 @@ Asynchronous `error` event handler are not blocking the `.receive()` method from
         <strong>Required.</strong>
         Method to be run each time a webhook event handler throws an error or returns a promise that rejects.
         The <code>handler</code> function can be an async function,
-        return a Promise. The handler is called with an error object that has a .event property which has all the information on the event: <code>{id, name, payload}</code>.
+        return a Promise. The handler is called with an error object that has a .event property which has all the information on the event: <code>{id, name, payload, extraData}</code>.
       </td>
     </tr>
   </tbody>
@@ -579,21 +581,32 @@ createServer(middleware).listen(3000);
       <td>
         <code>path</code>
         <em>
-          string
+          string | RegEx
         </em>
       </td>
       <td>
         Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>log</code>
-        <em>
-          object
-        </em>
-      </td>
-      <td>
+
+Can be used as a regular expression;
+
+```js
+const middleware = createNodeMiddleware(webhooks, {
+  path: /^\/api\/github\/webhooks/,
+});
+```
+
+Test the regex before usage, the `g` and `y` flags [makes it stateful](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)!
+
+</td>
+</tr>
+<tr>
+<td>
+<code>log</code>
+<em>
+object
+</em>
+</td>
+<td>
 
 Used for internal logging. Defaults to [`console`](https://developer.mozilla.org/en-US/docs/Web/API/console) with `debug` and `info` doing nothing.
 
@@ -721,7 +734,7 @@ A union of all possible events and event/action combinations supported by the ev
 
 ### `EmitterWebhookEvent`
 
-The object that is emitted by `@octokit/webhooks` as an event; made up of an `id`, `name`, and `payload` properties.
+The object that is emitted by `@octokit/webhooks` as an event; made up of an `id`, `name`, and `payload` properties, with an optional `extraData`.
 An optional generic parameter can be passed to narrow the type of the `name` and `payload` properties based on event names or event/action combinations, e.g. `EmitterWebhookEvent<"check_run" | "code_scanning_alert.fixed">`.
 
 ## License

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -33,8 +33,11 @@ export async function middleware(
     );
     return;
   }
-
-  const isUnknownRoute = request.method !== "POST" || pathname !== options.path;
+  const pathMatch =
+    options.path instanceof RegExp
+      ? options.path.test(pathname)
+      : pathname === options.path;
+  const isUnknownRoute = request.method !== "POST" || !pathMatch;
   const isExpressMiddleware = typeof next === "function";
   if (isUnknownRoute) {
     if (isExpressMiddleware) {
@@ -72,7 +75,12 @@ export async function middleware(
     didTimeout = true;
     response.statusCode = 202;
     response.end("still processing\n");
-  }, 9000).unref();
+  }, 9000);
+
+  /* istanbul ignore else */
+  if (typeof timeout.unref === "function") {
+    timeout.unref();
+  }
 
   try {
     const payload = await getPayload(request);
@@ -82,6 +90,7 @@ export async function middleware(
       name: eventName as any,
       payload: payload as any,
       signature: signatureSHA256,
+      extraData: request,
     });
     clearTimeout(timeout);
 

--- a/src/middleware/node/types.ts
+++ b/src/middleware/node/types.ts
@@ -7,7 +7,7 @@ type ServerResponse = any;
 import { Logger } from "../../createLogger";
 
 export type MiddlewareOptions = {
-  path?: string;
+  path?: string | RegExp;
   log?: Logger;
   onUnhandledRequest?: (
     request: IncomingMessage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type EmitterWebhookEvent<
 > = TEmitterEvent extends `${infer TWebhookEvent}.${infer TAction}`
   ? BaseWebhookEvent<Extract<TWebhookEvent, WebhookEventName>> & {
       payload: { action: TAction };
+    } & {
+      extraData?: any;
     }
   : BaseWebhookEvent<Extract<TEmitterEvent, WebhookEventName>>;
 
@@ -20,6 +22,7 @@ export type EmitterWebhookEventWithStringPayloadAndSignature = {
   name: EmitterWebhookEventName;
   payload: string;
   signature: string;
+  extraData?: any;
 };
 
 export type EmitterWebhookEventWithSignature = EmitterWebhookEvent & {
@@ -30,6 +33,7 @@ interface BaseWebhookEvent<TName extends WebhookEventName> {
   id: string;
   name: TName;
   payload: WebhookEventMap[TName];
+  extraData?: any;
 }
 
 export interface Options<TTransformed = unknown> {

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -39,5 +39,6 @@ export async function verifyAndReceive(
       typeof event.payload === "string"
         ? JSON.parse(event.payload)
         : event.payload,
+    extraData: event.extraData,
   });
 }


### PR DESCRIPTION
fixes #682 

There are three changes in this commit.
 - I added an option to match paths with regex
 - I pass down the original request to the handlers
 - ~~I typed the request and the response (as close as the code uses it)~~

The third mod could be opinionated. It matches the `http` interface and can be implemented in other HTTP frameworks too. Quick and dirty example for sunder;
```ts
import { Context } from "sunder";
import { ResponseData } from "sunder/util/response";
import { HeadersShorthands } from "sunder/context";

class WrappedRequest {
  request: Request & HeadersShorthands;
  headers: Record<string, string | string[] | undefined>;
  body: any;
  finished: Promise<unknown>;
  url: string;
  method: string;
  ctx: Context;
  setEncoding(enc: string) {};
  on(event: string, callback: (data: any) => void) {};

  constructor(ctx: Context) {
    const request = ctx.request;
    this.request = request;
    this.headers = Object.fromEntries(Array.from(request.headers.entries()));
    this.finished = request.json().then(async (d) => {
        this.body = d;
    });
    this.url = request.url;
    this.method = request.method;
    this.ctx = ctx;
  }
}

class WrappedResponse {
  response: ResponseData;

  set statusCode(value: number) {
    this.response.status = value;
  }

  end(body: string) {
    this.response.body = body;
  }

  writeHead(status: number, headers: Record<string, string>) {
    this.response.status = status;
    Object.entries(headers).map(([k, v]) => {
      this.response.headers.append(k, v);
    });
  }

  constructor(response: ResponseData) {
    this.response = response;
  }
}

export async function githubWebhooksMiddleware(ctx: Context, next: Function) {
  try {
    const request = new WrappedRequest(ctx);
    await request.finished;
    return webhooksMiddleware(
      request,
      new WrappedResponse(ctx.response),
      next
    );
  } catch (e) {
    console.log(e);
  }
}
```