### PR TITLE
Accept array of secrets, not just one

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require("http").createServer(createNodeMiddleware(webhooks)).listen(3000);
 To ease key rotation, one can also feed the `Webhook` constructor an array of
 secrets. Generate a new secret and update your Webhook receiver to accept both
 this new one and the current secret, then update GitHub to send the new secret,
-then update your Webhook receiver to accept only the new secret.  Signatures will
+then update your Webhook receiver to accept only the new secret. Signatures will
 always be made with the first secret.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ require("http").createServer(createNodeMiddleware(webhooks)).listen(3000);
 // can now receive webhook events at /api/github/webhooks
 ```
 
+To ease key rotation, one can also feed the `Webhook` constructor an array of
+secrets. Generate a new secret and update your Webhook receiver to accept
+both this new one and the current secret, then update GitHub to send the new
+secret, then update your Webhook receiver to accept only the new secret.
+
+```js
+const webhooks = new Webhooks({
+  secret: ["mynewsecret", "myoldsecret"],
+});
+```
+
 ## Local development
 
 You can receive webhooks on your local machine or even browser using [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) and [smee.io](https://smee.io/).
@@ -111,11 +122,13 @@ new Webhooks({ secret /*, transform */ });
         <code>
           secret
         </code>
-        <em>(String)</em>
+        <em>(String or String Array)</em>
       </td>
       <td>
         <strong>Required.</strong>
-        Secret as configured in GitHub Settings.
+        Secret as configured in GitHub Settings.  If an array of strings, an
+        incoming webhook event will be accepted if its signature verifies
+        with any of the secrets given.
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ require("http").createServer(createNodeMiddleware(webhooks)).listen(3000);
 ```
 
 To ease key rotation, one can also feed the `Webhook` constructor an array of
-secrets. Generate a new secret and update your Webhook receiver to accept
-both this new one and the current secret, then update GitHub to send the new
-secret, then update your Webhook receiver to accept only the new secret.
+secrets. Generate a new secret and update your Webhook receiver to accept both
+this new one and the current secret, then update GitHub to send the new secret,
+then update your Webhook receiver to accept only the new secret.  Signatures will
+always be made with the first secret.
 
 ```js
 const webhooks = new Webhooks({
@@ -128,7 +129,8 @@ new Webhooks({ secret /*, transform */ });
         <strong>Required.</strong>
         Secret as configured in GitHub Settings.  If an array of strings, an
         incoming webhook event will be accepted if its signature verifies
-        with any of the secrets given.
+        with any of the secrets given and signatures will always be generated
+        with the first secret.
       </td>
     </tr>
     <tr>

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,12 +43,12 @@ class Webhooks<TTransformed = unknown> {
       | EmitterWebhookEventWithSignature
   ) => Promise<void>;
 
-  constructor(options: Options<TTransformed> & { secret: string }) {
+  constructor(options: Options<TTransformed> & { secret: string | string[] }) {
     if (!options || !options.secret) {
       throw new Error("[@octokit/webhooks] options.secret required");
     }
 
-    const state: State & { secret: string } = {
+    const state: State & { secret: string | string[] } = {
       eventHandler: createEventHandler(options),
       secret: options.secret,
       hooks: {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,10 @@ class Webhooks<TTransformed = unknown> {
       log: createLogger(options.log),
     };
 
-    this.sign = sign.bind(null, options.secret);
+    const firstsecret =
+      typeof options.secret === "string" ? options.secret : options.secret[0];
+
+    this.sign = sign.bind(null, firstsecret);
     this.verify = verify.bind(null, options.secret);
     this.on = state.eventHandler.on;
     this.onAny = state.eventHandler.onAny;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ interface BaseWebhookEvent<TName extends WebhookEventName> {
 }
 
 export interface Options<TTransformed = unknown> {
-  secret?: string;
+  secret?: string | string[];
   transform?: TransformMethod<TTransformed>;
   log?: Partial<Logger>;
 }

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,6 +1,5 @@
-import { verify } from "@octokit/webhooks-methods";
+import { verify } from "./verify";
 
-import { toNormalizedJsonString } from "./to-normalized-json-string";
 import {
   EmitterWebhookEventWithStringPayloadAndSignature,
   EmitterWebhookEventWithSignature,
@@ -8,7 +7,7 @@ import {
 } from "./types";
 
 export async function verifyAndReceive(
-  state: State & { secret: string },
+  state: State & { secret: string | string[] },
   event:
     | EmitterWebhookEventWithStringPayloadAndSignature
     | EmitterWebhookEventWithSignature
@@ -16,9 +15,7 @@ export async function verifyAndReceive(
   // verify will validate that the secret is not undefined
   const matchesSignature = await verify(
     state.secret,
-    typeof event.payload === "object"
-      ? toNormalizedJsonString(event.payload)
-      : event.payload,
+    event.payload,
     event.signature
   );
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -11,5 +11,12 @@ export async function verify(
   const np =
     typeof payload === "string" ? payload : toNormalizedJsonString(payload);
 
-  return secrets.some((s: string) => verifyMethod(s, np, signature));
+  for (const s of secrets) {
+    const v : boolean = await verifyMethod(s, np, signature);
+    if (v) {
+      return v;
+    }
+  }
+
+  return false;
 }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -3,13 +3,13 @@ import { verify as verifyMethod } from "@octokit/webhooks-methods";
 import { toNormalizedJsonString } from "./to-normalized-json-string";
 
 export async function verify(
-  secret: string,
+  secret: string | string[],
   payload: string | object,
   signature: string
 ): Promise<any> {
-  return verifyMethod(
-    secret,
-    typeof payload === "string" ? payload : toNormalizedJsonString(payload),
-    signature
-  );
+  const secrets = typeof secret === "string" ? [secret] : secret;
+  const np =
+    typeof payload === "string" ? payload : toNormalizedJsonString(payload);
+
+  return secrets.some((s: string) => verifyMethod(s, np, signature));
 }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -12,7 +12,7 @@ export async function verify(
     typeof payload === "string" ? payload : toNormalizedJsonString(payload);
 
   for (const s of secrets) {
-    const v : boolean = await verifyMethod(s, np, signature);
+    const v: boolean = await verifyMethod(s, np, signature);
     if (v) {
       return v;
     }

--- a/test/integration/webhooks.test.ts
+++ b/test/integration/webhooks.test.ts
@@ -81,6 +81,22 @@ describe("Webhooks", () => {
     });
   });
 
+  test("webhooks.verifyAndReceive({ ...event, signature }) with one of several secrets", async () => {
+    const secret1 = "mysecret";
+    const secret2 = "mysecret2";
+    const webhooks = new Webhooks({ secret: [secret1, secret2] });
+
+    await webhooks.verifyAndReceive({
+      id: "1",
+      name: "push",
+      payload: pushEventPayloadString,
+      signature: await sign(
+        { secret: secret2, algorithm: "sha256" },
+        pushEventPayloadString
+      ),
+    });
+  });
+
   test("webhooks.verifyAndReceive(event) with incorrect signature", async () => {
     const webhooks = new Webhooks({ secret: "mysecret" });
 

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -69,6 +69,11 @@ export default async function () {
     secret: "blah",
   });
 
+  // Check that secret can be an array, too
+  new Webhooks({
+    secret: ["blah", "bleh"],
+  });
+
   // Check all supported options
   const webhooks = new Webhooks({
     secret: "blah",


### PR DESCRIPTION
Resolves #770.

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Only one secret could be specified for a WebHook object.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* A bare secret or an array of secrets are each accepted.  In the latter case, any match will be accepted.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [x] No

### Pull request type

I do not seem to be able to add labels, but please add `Type: Feature` for me?

----

