### PR TITLE
ci(codeql): set env variable `CODEQL_ACTION_RUN_MODE`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
           languages: ${{ matrix.language }}
       - name: Autobuild
         env:
-          CODEQL_ACTION_RUN_MODE: action
+          CODEQL_ACTION_RUN_MODE: Action
         uses: >-
           github/codeql-action/autobuild@86f3159a697a097a813ad9bfa0002412d97690a4
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
+        env:
+          CODEQL_ACTION_RUN_MODE: action
         uses: >-
           github/codeql-action/autobuild@86f3159a697a097a813ad9bfa0002412d97690a4
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
The CodeQL tests are failing, and this was a solution in another of the repos
ref: https://github.com/octokit/fixtures/commit/8642c27ddee746ec9a00a97ac28bdaf823046b2b
