### PR TITLE
fix: handle missing `Content-Type` header with `null` check

### DIFF
--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -48,7 +48,7 @@ export async function middleware(
   // Otherwise, return a 415 Unsupported Media Type error
   // See https://github.com/octokit/webhooks.js/issues/158
   if (
-    request.headers["content-type"] == null ||
+    !request.headers["content-type"] ||
     !request.headers["content-type"].startsWith("application/json")
   ) {
     response.writeHead(415, {

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -47,7 +47,10 @@ export async function middleware(
   // Check if the Content-Type header is `application/json` and allow for charset to be specified in it
   // Otherwise, return a 415 Unsupported Media Type error
   // See https://github.com/octokit/webhooks.js/issues/158
-  if (request.headers["content-type"] == null || !request.headers["content-type"].startsWith("application/json")) {
+  if (
+    request.headers["content-type"] == null ||
+    !request.headers["content-type"].startsWith("application/json")
+  ) {
     response.writeHead(415, {
       "content-type": "application/json",
       accept: "application/json",

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(
   // Check if the Content-Type header is `application/json` and allow for charset to be specified in it
   // Otherwise, return a 415 Unsupported Media Type error
   // See https://github.com/octokit/webhooks.js/issues/158
-  if (!request.headers["content-type"].startsWith("application/json")) {
+  if (request.headers["content-type"] == null ||  !request.headers["content-type"].startsWith("application/json")) {
     response.writeHead(415, {
       "content-type": "application/json",
       accept: "application/json",

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(
   // Check if the Content-Type header is `application/json` and allow for charset to be specified in it
   // Otherwise, return a 415 Unsupported Media Type error
   // See https://github.com/octokit/webhooks.js/issues/158
-  if (request.headers["content-type"] == null ||  !request.headers["content-type"].startsWith("application/json")) {
+  if (request.headers["content-type"] == null || !request.headers["content-type"].startsWith("application/json")) {
     response.writeHead(415, {
       "content-type": "application/json",
       accept: "application/json",

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -138,7 +138,7 @@ describe("createNodeMiddleware(webhooks)", () => {
 
     server.close();
   });
-  
+
   test("Handles Missing Content-Type", async () => {
     const webhooks = new Webhooks({
       secret: "mySecret",


### PR DESCRIPTION
Resolves #804

----

## Behavior

### Before the change?
Submitting a POST request to listening webhook endpoints with no content-type header can cause DOS conditions due to missing null check in middleware handler.


### After the change?
Submitting a POST request to listening webhook endpoints with no content-type header behaves the same as if you had submitted any other non-"application/json" content-type header and supplies a friendly error message.



### Other information
Introduced by https://github.com/octokit/webhooks.js/commit/b7aee15b00537e2ec655eb461892b8b42005495c


----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
I can't seem to set the label :(
----

