### PR TITLE
Ease key rotation via an array of fallback secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ require("http").createServer(createNodeMiddleware(webhooks)).listen(3000);
 // can now receive webhook events at /api/github/webhooks
 ```
 
+To ease key rotation, the `Webhooks` constructor also accepts an array of additional secrets used as fallbacks for verification.
+That is, if a message fails to verify with the provided `secret`, the receiver will also test against each of these additional secrets.
+The message will be accepted if it verifies against any secret.
+
+```js
+const webhooks = new Webhooks({
+  secret: "mysecret",
+  alternativeSecretsForVerification: ["oldsecret1", "oldsecret2"],
+});
+```
+
 ## Local development
 
 You can receive webhooks on your local machine or even browser using [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) and [smee.io](https://smee.io/).
@@ -143,6 +154,19 @@ Used for internal logging. Defaults to [`console`](https://developer.mozilla.org
 
 </td>
     </tr>
+    <tr>
+      <td>
+        <code>
+          alternativeSecretsForVerification
+        </code>
+        <em>(Array of Strings)</em>
+      </td>
+      <td>
+        Additional secrets, as configured in GitHub Settings, to use as fallbacks for incoming messages.
+        This is intended to facilitate key rotation, and so will usually be null or an empty array.
+      </td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ class Webhooks<TTransformed = unknown> {
     const state: State & { secret: string } = {
       eventHandler: createEventHandler(options),
       secret: options.secret,
+      alternativeSecretsForVerification:
+        options.alternativeSecretsForVerification,
       hooks: {},
       log: createLogger(options.log),
     };
@@ -66,7 +68,12 @@ class Webhooks<TTransformed = unknown> {
           "[@octokit/webhooks] Passing a JSON payload object to `verify()` is deprecated and the functionality will be removed in a future release of `@octokit/webhooks`"
         );
       }
-      return verify(options.secret, eventPayload, signature);
+      return verify(
+        options.secret,
+        options.alternativeSecretsForVerification,
+        eventPayload,
+        signature
+      );
     };
     this.on = state.eventHandler.on;
     this.onAny = state.eventHandler.onAny;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ interface BaseWebhookEvent<TName extends WebhookEventName> {
 
 export interface Options<TTransformed = unknown> {
   secret?: string;
+  alternativeSecretsForVerification?: string[];
   transform?: TransformMethod<TTransformed>;
   log?: Partial<Logger>;
 }

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,6 +1,5 @@
-import { verify } from "@octokit/webhooks-methods";
+import { verify } from "./verify";
 
-import { toNormalizedJsonString } from "./to-normalized-json-string";
 import {
   EmitterWebhookEventWithStringPayloadAndSignature,
   EmitterWebhookEventWithSignature,
@@ -16,9 +15,8 @@ export async function verifyAndReceive(
   // verify will validate that the secret is not undefined
   const matchesSignature = await verify(
     state.secret,
-    typeof event.payload === "object"
-      ? toNormalizedJsonString(event.payload)
-      : event.payload,
+    state.alternativeSecretsForVerification,
+    event.payload,
     event.signature
   );
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -4,12 +4,27 @@ import { toNormalizedJsonString } from "./to-normalized-json-string";
 
 export async function verify(
   secret: string,
+  additionalSecrets: undefined | string[],
   payload: string | object,
   signature: string
 ): Promise<any> {
-  return verifyMethod(
-    secret,
-    typeof payload === "string" ? payload : toNormalizedJsonString(payload),
-    signature
-  );
+  const normPayload =
+    typeof payload === "string" ? payload : toNormalizedJsonString(payload);
+
+  const firstPass = await verifyMethod(secret, normPayload, signature);
+
+  if (firstPass) {
+    return true;
+  }
+
+  if (additionalSecrets !== undefined) {
+    for (const s of additionalSecrets) {
+      const v: boolean = await verifyMethod(s, normPayload, signature);
+      if (v) {
+        return v;
+      }
+    }
+  }
+
+  return false;
 }

--- a/test/integration/webhooks.test.ts
+++ b/test/integration/webhooks.test.ts
@@ -71,6 +71,25 @@ describe("Webhooks", () => {
     });
   });
 
+  test("webhooks.verifyAndReceive({ ...event, signature }) with one of several secrets", async () => {
+    const secret1 = "mysecret";
+    const secret2 = "mysecret2";
+    const webhooks = new Webhooks({
+      secret: secret1,
+      alternativeSecretsForVerification: [secret2],
+    });
+
+    await webhooks.verifyAndReceive({
+      id: "1",
+      name: "push",
+      payload: pushEventPayloadString,
+      signature: await sign(
+        { secret: secret2, algorithm: "sha256" },
+        pushEventPayloadString
+      ),
+    });
+  });
+
   test("webhooks.verifyAndReceive(event) with incorrect signature", async () => {
     const webhooks = new Webhooks({ secret: "mysecret" });
 

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -72,6 +72,7 @@ export default async function () {
   // Check all supported options
   const webhooks = new Webhooks({
     secret: "blah",
+    alternativeSecretsForVerification: ["oldblah"],
     transform: (event) => {
       console.log(event.payload);
       return Object.assign(event, { foo: "bar" });


### PR DESCRIPTION
The core change is in src/verify.ts.  We don't really have to do anything special here for constant-timedness.  Since each comparison is constant time, the only timing differential is between all checks (completely) failing and some check (completely) succeeding, and so the only thing learned is whether a guess was completely right or wrong.

The rest of the changes here are plumbing this new mechanism up to the top level and testing.

As suggested by @gr2m on https://github.com/octokit/webhooks.js/pull/777

Resolves #770.

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Only one secret could be specified for a WebHook object.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Additional secrets are accepted for verification

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [x] No

### Pull request type

I do not seem to be able to add labels, but please add `Type: Feature` for me?

----

