### PR TITLE
chore: explicitly mark imports/exports that are only used as types

### DIFF
--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,5 +1,5 @@
 import { emitterEventNames } from "../generated/webhook-names";
-import {
+import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
   State,

--- a/src/event-handler/remove-listener.ts
+++ b/src/event-handler/remove-listener.ts
@@ -1,4 +1,4 @@
-import { EmitterWebhookEventName, State } from "../types";
+import type { EmitterWebhookEventName, State } from "../types";
 
 export function removeListener(
   state: State,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createEventHandler } from "./event-handler/index";
 import { sign } from "./sign";
 import { verify } from "./verify";
 import { verifyAndReceive } from "./verify-and-receive";
-import {
+import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
   HandlerFunction,
@@ -91,7 +91,7 @@ class Webhooks<TTransformed = unknown> {
 export {
   createEventHandler,
   Webhooks,
-  EmitterWebhookEvent,
-  EmitterWebhookEventName,
-  WebhookError,
+  type EmitterWebhookEvent,
+  type EmitterWebhookEventName,
+  type WebhookError,
 };

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -1,4 +1,4 @@
-import { WebhookEvent } from "@octokit/webhooks-types";
+import type { WebhookEvent } from "@octokit/webhooks-types";
 // @ts-ignore to address #245
 import AggregateError from "aggregate-error";
 

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -1,8 +1,8 @@
 import { createLogger } from "../../createLogger";
-import { Webhooks } from "../../index";
+import type { Webhooks } from "../../index";
 import { middleware } from "./middleware";
 import { onUnhandledRequestDefault } from "./on-unhandled-request-default";
-import { MiddlewareOptions } from "./types";
+import type { MiddlewareOptions } from "./types";
 
 export function createNodeMiddleware(
   webhooks: Webhooks,

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -4,11 +4,11 @@
 type IncomingMessage = any;
 type ServerResponse = any;
 
-import { WebhookEventName } from "@octokit/webhooks-types";
+import type { WebhookEventName } from "@octokit/webhooks-types";
 
-import { Webhooks } from "../../index";
-import { WebhookEventHandlerError } from "../../types";
-import { MiddlewareOptions } from "./types";
+import type { Webhooks } from "../../index";
+import type { WebhookEventHandlerError } from "../../types";
+import type { MiddlewareOptions } from "./types";
 import { getMissingHeaders } from "./get-missing-headers";
 import { getPayload } from "./get-payload";
 

--- a/src/middleware/node/types.ts
+++ b/src/middleware/node/types.ts
@@ -4,7 +4,7 @@
 type IncomingMessage = any;
 type ServerResponse = any;
 
-import { Logger } from "../../createLogger";
+import type { Logger } from "../../createLogger";
 
 export type MiddlewareOptions = {
   path?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
-import { RequestError } from "@octokit/request-error";
+import type { RequestError } from "@octokit/request-error";
 import type {
   WebhookEventMap,
   WebhookEventName,
 } from "@octokit/webhooks-types";
-import { Logger } from "./createLogger";
+import type { Logger } from "./createLogger";
 import type { emitterEventNames } from "./generated/webhook-names";
 
 export type EmitterWebhookEventName = (typeof emitterEventNames)[number];

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,7 +1,7 @@
 import { verify } from "@octokit/webhooks-methods";
 
 import { toNormalizedJsonString } from "./to-normalized-json-string";
-import {
+import type {
   EmitterWebhookEventWithStringPayloadAndSignature,
   EmitterWebhookEventWithSignature,
   State,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Some compilers that don't fully parse typescript, ex: Babel and esbuild, would include these imports/exports in the build output

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* With the explicit markers, those imports/exports aren't included in the build output


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

