### PR TITLE
build: fix type generation script

### DIFF
--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -2,7 +2,7 @@
 
 import { strict as assert } from "assert";
 import * as fs from "fs";
-import { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
 import { format } from "prettier";
 
 type JSONSchemaWithRef = JSONSchema7 & Required<Pick<JSONSchema7, "$ref">>;


### PR DESCRIPTION
Due to the recent changes to the `tsconfig.json`, type imports need to be marked as such, so that the compiler knows to strip it out from the output. By marking the type import, the script now runs correctly

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The script would fail to run due to the `json-schema` module not being found

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The script now finishes without failing due to the type import of `json-schema`

### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

