### PR TITLE
chore: remove .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-	"presets": ["@babel/preset-env"]
-}


### PR DESCRIPTION
I think the .babelrc is an artifact