### PR TITLE
fix: only parse payload once

### DIFF
--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -26,15 +26,7 @@ export function getPayload(request: IncomingMessage): Promise<string> {
     request.on("error", (error: Error) => reject(new AggregateError([error])));
     request.on("data", (chunk: string) => (data += chunk));
     request.on("end", () => {
-      try {
-        // Call JSON.parse() only to check if the payload is valid JSON
-        JSON.parse(data);
-        resolve(data);
-      } catch (error: any) {
-        error.message = "Invalid JSON";
-        error.status = 400;
-        reject(new AggregateError([error]));
-      }
+      resolve(data);
     });
   });
 }

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -25,8 +25,6 @@ export function getPayload(request: IncomingMessage): Promise<string> {
     // istanbul ignore next
     request.on("error", (error: Error) => reject(new AggregateError([error])));
     request.on("data", (chunk: string) => (data += chunk));
-    request.on("end", () => {
-      resolve(data);
-    });
+    request.on("end", () => resolve(data));
   });
 }

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -36,11 +36,6 @@ export async function verifyAndReceive(
   } catch (error: any) {
     error.message = "Invalid JSON";
     error.status = 400;
-    let tmpStackTraceLimit = Error.stackTraceLimit;
-    Error.stackTraceLimit = 0;
-    const aggregateError = new AggregateError([error]);
-    Error.stackTraceLimit = tmpStackTraceLimit;
-    aggregateError.stack = error.stack;
-    throw aggregateError;
+    throw new AggregateError([error]);
   }
 }

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -178,6 +178,8 @@ describe("createNodeMiddleware(webhooks)", () => {
     // @ts-expect-error complains about { port } although it's included in returned AddressInfo interface
     const { port } = server.address();
 
+    const payload = '{"name":"invalid"';
+
     const response = await fetch(
       `http://localhost:${port}/api/github/webhooks`,
       {
@@ -186,9 +188,9 @@ describe("createNodeMiddleware(webhooks)", () => {
           "Content-Type": "application/json",
           "X-GitHub-Delivery": "123e4567-e89b-12d3-a456-426655440000",
           "X-GitHub-Event": "push",
-          "X-Hub-Signature-256": signatureSha256,
+          "X-Hub-Signature-256": await sign("mySecret", payload),
         },
-        body: "invalid",
+        body: payload,
       },
     );
 


### PR DESCRIPTION
Closes #922 

We are parsing the JSON twice. Also it is quite dangerous to parse unverified data. So it is better to first verify and then parse it with the very low risk that it is broken payload. 

Improves the performance of the valid path in probot beta from 63 k ops/s to 71 k ops/s.