### PR TITLE
fix(typescript): workaround for trouble with `aggregate-error` type export

### DIFF
--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,3 +1,4 @@
+// @ts-ignore to address #245
 import AggregateError from "aggregate-error";
 import { verify } from "@octokit/webhooks-methods";
 


### PR DESCRIPTION
This wasn't copied across in #921 and I believe it's still a problem