### PR TITLE
fix: pass through `TTransformed` to `onAny` and `onError`

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -21,7 +21,9 @@ interface EventHandler<TTransformed> {
     callback: HandlerFunction<E, TTransformed>,
   ): void;
   onAny(handler: (event: EmitterWebhookEvent & TTransformed) => any): void;
-  onError(handler: (event: WebhookEventHandlerError<TTransformed>) => any): void;
+  onError(
+    handler: (event: WebhookEventHandlerError<TTransformed>) => any,
+  ): void;
   removeListener<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -20,8 +20,8 @@ interface EventHandler<TTransformed> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
   ): void;
-  onAny(handler: (event: EmitterWebhookEvent) => any): void;
-  onError(handler: (event: WebhookEventHandlerError) => any): void;
+  onAny(handler: (event: EmitterWebhookEvent & TTransformed) => any): void;
+  onError(handler: (event: WebhookEventHandlerError<TTransformed>) => any): void;
   removeListener<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
@@ -43,8 +43,8 @@ export function createEventHandler<TTransformed>(
 
   return {
     on: on.bind(null, state),
-    onAny: onAny.bind(null, state),
-    onError: onError.bind(null, state),
+    onAny: (onAny<TTransformed>).bind(null, state),
+    onError: (onError<TTransformed>).bind(null, state),
     removeListener: removeListener.bind(null, state),
     receive: receive.bind(null, state),
   };

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -49,16 +49,16 @@ export function receiverOn(
   handleEventHandlers(state, webhookNameOrNames, handler);
 }
 
-export function receiverOnAny(
+export function receiverOnAny<TTransformed>(
   state: State,
-  handler: (event: EmitterWebhookEvent) => any,
+  handler: (event: EmitterWebhookEvent & TTransformed) => any,
 ) {
   handleEventHandlers(state, "*", handler);
 }
 
-export function receiverOnError(
+export function receiverOnError<TTransformed>(
   state: State,
-  handler: (event: WebhookEventHandlerError) => any,
+  handler: (event: WebhookEventHandlerError<TTransformed>) => any,
 ) {
   handleEventHandlers(state, "error", handler);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ class Webhooks<TTransformed = unknown> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
   ) => void;
-  public onAny: (callback: (event: EmitterWebhookEvent) => any) => void;
-  public onError: (callback: (event: WebhookEventHandlerError) => any) => void;
+  public onAny: (callback: (event: EmitterWebhookEvent & TTransformed) => any) => void;
+  public onError: (callback: (event: WebhookEventHandlerError<TTransformed>) => any) => void;
   public removeListener: <E extends EmitterWebhookEventName | "*">(
     event: E | E[],
     callback: RemoveHandlerFunction<E, TTransformed>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,12 @@ class Webhooks<TTransformed = unknown> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
   ) => void;
-  public onAny: (callback: (event: EmitterWebhookEvent & TTransformed) => any) => void;
-  public onError: (callback: (event: WebhookEventHandlerError<TTransformed>) => any) => void;
+  public onAny: (
+    callback: (event: EmitterWebhookEvent & TTransformed) => any,
+  ) => void;
+  public onError: (
+    callback: (event: WebhookEventHandlerError<TTransformed>) => any,
+  ) => void;
   public removeListener: <E extends EmitterWebhookEventName | "*">(
     event: E | E[],
     callback: RemoveHandlerFunction<E, TTransformed>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,8 @@ export interface State extends Options<any> {
 export type WebhookError = Error & Partial<RequestError>;
 
 // todo: rename to "EmitterErrorEvent"
-export interface WebhookEventHandlerError<TTransformed = unknown> extends AggregateError<WebhookError> {
+export interface WebhookEventHandlerError<TTransformed = unknown>
+  extends AggregateError<WebhookError> {
   event: EmitterWebhookEvent & TTransformed;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,8 +62,8 @@ export interface State extends Options<any> {
 export type WebhookError = Error & Partial<RequestError>;
 
 // todo: rename to "EmitterErrorEvent"
-export interface WebhookEventHandlerError extends AggregateError<WebhookError> {
-  event: EmitterWebhookEvent;
+export interface WebhookEventHandlerError<TTransformed = unknown> extends AggregateError<WebhookError> {
+  event: EmitterWebhookEvent & TTransformed;
 }
 
 /**


### PR DESCRIPTION
See https://github.com/probot/probot/issues/1643

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When users would pass a transform option the type would not be passed down to the `onAny` and `onError` functions

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The transform option is passed down

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

