### PR TITLE
fix(types): limit recursion in types using ternary statements

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -15,7 +15,7 @@ import {
 import { receiverHandle as receive } from "./receive.js";
 import { removeListener } from "./remove-listener.js";
 
-interface EventHandler<TTransformed = unknown> {
+interface EventHandler<TTransformed> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -15,12 +15,12 @@ import {
 import { receiverHandle as receive } from "./receive.js";
 import { removeListener } from "./remove-listener.js";
 
-interface EventHandler<TTransformed> {
+interface EventHandler<TTransformed = unknown> {
   on<E extends EmitterWebhookEventName>(
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
   ): void;
-  onAny(handler: (event: EmitterWebhookEvent & TTransformed) => any): void;
+  onAny(handler: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any): void;
   onError(
     handler: (event: WebhookEventHandlerError<TTransformed>) => any,
   ): void;

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -20,7 +20,13 @@ interface EventHandler<TTransformed = unknown> {
     event: E | E[],
     callback: HandlerFunction<E, TTransformed>,
   ): void;
-  onAny(handler: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any): void;
+  onAny(
+    handler: (
+      event: TTransformed extends unknown
+        ? EmitterWebhookEvent
+        : EmitterWebhookEvent & TTransformed,
+    ) => any,
+  ): void;
   onError(
     handler: (event: WebhookEventHandlerError<TTransformed>) => any,
   ): void;

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -51,7 +51,7 @@ export function receiverOn(
 
 export function receiverOnAny<TTransformed>(
   state: State,
-  handler: (event: EmitterWebhookEvent & TTransformed) => any,
+  handler: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any,
 ) {
   handleEventHandlers(state, "*", handler);
 }

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -51,7 +51,11 @@ export function receiverOn(
 
 export function receiverOnAny<TTransformed>(
   state: State,
-  handler: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any,
+  handler: (
+    event: TTransformed extends unknown
+      ? EmitterWebhookEvent
+      : EmitterWebhookEvent & TTransformed,
+  ) => any,
 ) {
   handleEventHandlers(state, "*", handler);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,11 @@ class Webhooks<TTransformed = unknown> {
     callback: HandlerFunction<E, TTransformed>,
   ) => void;
   public onAny: (
-    callback: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any,
+    callback: (
+      event: TTransformed extends unknown
+        ? EmitterWebhookEvent
+        : EmitterWebhookEvent & TTransformed,
+    ) => any,
   ) => void;
   public onError: (
     callback: (event: WebhookEventHandlerError<TTransformed>) => any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ class Webhooks<TTransformed = unknown> {
     callback: HandlerFunction<E, TTransformed>,
   ) => void;
   public onAny: (
-    callback: (event: EmitterWebhookEvent & TTransformed) => any,
+    callback: (event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed) => any,
   ) => void;
   public onError: (
     callback: (event: WebhookEventHandlerError<TTransformed>) => any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,9 @@ export type WebhookError = Error & Partial<RequestError>;
 // todo: rename to "EmitterErrorEvent"
 export interface WebhookEventHandlerError<TTransformed = unknown>
   extends AggregateError<WebhookError> {
-  event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed;
+  event: TTransformed extends unknown
+    ? EmitterWebhookEvent
+    : EmitterWebhookEvent & TTransformed;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export type WebhookError = Error & Partial<RequestError>;
 // todo: rename to "EmitterErrorEvent"
 export interface WebhookEventHandlerError<TTransformed = unknown>
   extends AggregateError<WebhookError> {
-  event: EmitterWebhookEvent & TTransformed;
+  event: TTransformed extends unknown ? EmitterWebhookEvent : EmitterWebhookEvent & TTransformed;
 }
 
 /**


### PR DESCRIPTION
Resolves #926

@wolfy1339 

It seems that this results in building again properly on probot. 
But I dont know if this is what you expect.

I used `npm link` to test if it builds again in probot. And it builds again

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

