### PR TITLE
fix: simplify routing in createNodeMiddleware

### DIFF
--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -20,25 +20,12 @@ export async function middleware(
   response: ServerResponse,
   next?: Function,
 ): Promise<boolean> {
-  let pathname: string;
-  try {
-    pathname = new URL(request.url as string, "http://localhost").pathname;
-  } catch (error) {
-    response.writeHead(422, {
-      "content-type": "application/json",
-    });
-    response.end(
-      JSON.stringify({
-        error: `Request URL could not be parsed: ${request.url}`,
-      }),
-    );
-    return true;
-  }
-
-  if (pathname !== options.path) {
+  if (request.url !== options.path) {
     next?.();
     return false;
-  } else if (request.method !== "POST") {
+  }
+
+  if (request.method !== "POST") {
     onUnhandledRequestDefault(request, response);
     return true;
   }

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -564,49 +564,6 @@ describe("createNodeMiddleware(webhooks)", () => {
     server.close();
   });
 
-  test("Handles invalid URL", async () => {
-    const webhooks = new Webhooks({
-      secret: "mySecret",
-    });
-
-    let middlewareWasRan: () => void;
-    const untilMiddlewareIsRan = new Promise<void>(function (resolve) {
-      middlewareWasRan = resolve;
-    });
-    const actualMiddleware = createNodeMiddleware(webhooks);
-    const mockedMiddleware = async function (
-      ...[req, ...rest]: Parameters<typeof actualMiddleware>
-    ) {
-      req.url = "//";
-      await actualMiddleware(req, ...rest);
-      middlewareWasRan();
-    };
-    const server = createServer(mockedMiddleware).listen();
-
-    // @ts-expect-error complains about { port } although it's included in returned AddressInfo interface
-    const { port } = server.address();
-
-    const response = await fetch(
-      `http://localhost:${port}/api/github/webhooks`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-GitHub-Delivery": "123e4567-e89b-12d3-a456-426655440000",
-          "X-GitHub-Event": "push",
-          "X-Hub-Signature-256": signatureSha256,
-        },
-        body: pushEventPayload,
-      },
-    );
-
-    await untilMiddlewareIsRan;
-    expect(response.status).toEqual(422);
-    expect(await response.text()).toMatch(/Request URL could not be parsed/);
-
-    server.close();
-  });
-
   test("Handles invalid signature", async () => {
     expect.assertions(3);
 


### PR DESCRIPTION
Actually I dont get why we should actually take care of invalid routes. The original issue arose because we use new URL call, which throws an error on the example "//". I assume that new URL was used to ensure, that ankers `#` and querystrings are parsed away to get the actual pathname. 

I say, this is unnecessary. We just need to check if the pathname is equal to the options.path. We dont handle querystrings and ankers, so we can boil this down to this simple solution. 

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

