### PR TITLE
fix: handle gcf, verify already provided request.body

### DIFF
--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -17,7 +17,7 @@ export function getPayload(request: IncomingMessage): Promise<Buffer> {
 
     // istanbul ignore next
     request.on("error", (error: Error) => reject(new AggregateError([error])));
-    request.on("data", data.push.bind(data));
+    request.on("data", (chunk: string) => data.push(chunk);
     // istanbul ignore next
     request.on("end", () =>
       setImmediate(resolve, data.length === 1 ? data[0] : Buffer.concat(data)),

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -12,8 +12,6 @@ import AggregateError from "aggregate-error";
 type IncomingMessage = any;
 
 export function getPayload(request: IncomingMessage): Promise<Buffer> {
-  // If request.body already exists we can stop here
-  // See https://github.com/octokit/webhooks.js/pull/23
   return new Promise((resolve, reject) => {
     let data: Buffer[] = [];
 

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -11,20 +11,15 @@ import AggregateError from "aggregate-error";
 // }
 type IncomingMessage = any;
 
-export function getPayload(request: IncomingMessage): Promise<string> {
+export function getPayload(request: IncomingMessage): Promise<Buffer> {
   // If request.body already exists we can stop here
   // See https://github.com/octokit/webhooks.js/pull/23
-
-  if (request.body) return Promise.resolve(request.body);
-
   return new Promise((resolve, reject) => {
-    let data = "";
-
-    request.setEncoding("utf8");
+    let data: Buffer[] = [];
 
     // istanbul ignore next
     request.on("error", (error: Error) => reject(new AggregateError([error])));
-    request.on("data", (chunk: string) => (data += chunk));
-    request.on("end", () => resolve(data));
+    request.on("data", (chunk: Buffer) => data.push(chunk));
+    request.on("end", () => resolve(Buffer.concat(data)));
   });
 }

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -20,6 +20,8 @@ export function getPayload(request: IncomingMessage): Promise<Buffer> {
     request.on("data", (chunk: string) => data.push(chunk);
     // istanbul ignore next
     request.on("end", () =>
+      // setImmediate improves the throughput by reducing the pressure from
+      // the event loop
       setImmediate(resolve, data.length === 1 ? data[0] : Buffer.concat(data)),
     );
   });

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -17,7 +17,10 @@ export function getPayload(request: IncomingMessage): Promise<Buffer> {
 
     // istanbul ignore next
     request.on("error", (error: Error) => reject(new AggregateError([error])));
-    request.on("data", (chunk: Buffer) => data.push(chunk));
-    request.on("end", () => resolve(Buffer.concat(data)));
+    request.on("data", data.push.bind(data));
+    // istanbul ignore next
+    request.on("end", () =>
+      setImmediate(resolve, data.length === 1 ? data[0] : Buffer.concat(data)),
+    );
   });
 }

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -17,7 +17,7 @@ export function getPayload(request: IncomingMessage): Promise<Buffer> {
 
     // istanbul ignore next
     request.on("error", (error: Error) => reject(new AggregateError([error])));
-    request.on("data", (chunk: string) => data.push(chunk);
+    request.on("data", (chunk: Buffer) => data.push(chunk));
     // istanbul ignore next
     request.on("end", () =>
       // setImmediate improves the throughput by reducing the pressure from

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -82,10 +82,10 @@ export async function middleware(
     "x-hub-signature-256": signature,
     "x-github-delivery": id,
   } = request.headers as {
-    'x-github-event': WebhookEventName;
-    'x-hub-signature-256': string;
-    'x-github-delivery': string;
-  }
+    "x-github-event": WebhookEventName;
+    "x-hub-signature-256": string;
+    "x-github-delivery": string;
+  };
   options.log.debug(`${name} event received (id: ${id})`);
 
   // GitHub will abort the request if it does not receive a response within 10s

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -77,8 +77,8 @@ export async function middleware(
     return true;
   }
 
-  const eventName = request.headers["x-github-event"] as WebhookEventName;
-  const signatureSHA256 = request.headers["x-hub-signature-256"] as string;
+  const name = request.headers["x-github-event"] as WebhookEventName;
+  const signature = request.headers["x-hub-signature-256"] as string;
   const id = request.headers["x-github-delivery"] as string;
   options.log.debug(`${name} event received (id: ${id})`);
 

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -77,15 +77,9 @@ export async function middleware(
     return true;
   }
 
-  const {
-    "x-github-event": name,
-    "x-hub-signature-256": signature,
-    "x-github-delivery": id,
-  } = request.headers as {
-    "x-github-event": WebhookEventName;
-    "x-hub-signature-256": string;
-    "x-github-delivery": string;
-  };
+  const eventName = request.headers["x-github-event"] as WebhookEventName;
+  const signatureSHA256 = request.headers["x-hub-signature-256"] as string;
+  const id = request.headers["x-github-delivery"] as string;
   options.log.debug(`${name} event received (id: ${id})`);
 
   // GitHub will abort the request if it does not receive a response within 10s

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -99,7 +99,6 @@ export async function middleware(
 
   try {
     let payload: Buffer;
-    let body: { [key: string]: any } | undefined;
 
     if ("body" in request) {
       if (
@@ -108,7 +107,6 @@ export async function middleware(
         request.rawBody instanceof Buffer
       ) {
         // The body is already an Object and rawBody is a Buffer (e.g. GCF)
-        body = request.body;
         payload = request.rawBody;
       } else {
         // The body is a String (e.g. Lambda)
@@ -123,7 +121,6 @@ export async function middleware(
       id,
       name,
       payload,
-      body,
       signature,
     });
     clearTimeout(timeout);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,8 @@ export type EmitterWebhookEvent<
 export type EmitterWebhookEventWithStringPayloadAndSignature = {
   id: string;
   name: EmitterWebhookEventName;
-  payload: string;
+  body?: { [key: string]: any };
+  payload: string | Buffer;
   signature: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@ export type EmitterWebhookEvent<
 export type EmitterWebhookEventWithStringPayloadAndSignature = {
   id: string;
   name: EmitterWebhookEventName;
-  body?: { [key: string]: any };
   payload: string | Buffer;
   signature: string;
 };

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -39,7 +39,7 @@ export async function verifyAndReceive(
     });
   }
 
-  let payload;
+  let payload: EmitterWebhookEvent["payload"];
 
   try {
     payload =

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -39,20 +39,22 @@ export async function verifyAndReceive(
     });
   }
 
-  const payload =
-    typeof event.payload === "string"
-      ? event.payload
-      : event.payload.toString("utf8");
+  let payload;
 
   try {
-    return state.eventHandler.receive({
-      id: event.id,
-      name: event.name,
-      payload: JSON.parse(payload) as EmitterWebhookEvent["payload"],
-    });
+    payload =
+      typeof event.payload === "string"
+        ? JSON.parse(event.payload)
+        : JSON.parse(event.payload.toString("utf8"));
   } catch (error: any) {
     error.message = "Invalid JSON";
     error.status = 400;
     throw new AggregateError([error]);
   }
+
+  return state.eventHandler.receive({
+    id: event.id,
+    name: event.name,
+    payload,
+  });
 }

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -30,15 +30,6 @@ export async function verifyAndReceive(
     );
   }
 
-  // The body is already an Object (e.g. GCF) and can be passed directly to the EventHandler
-  if (event.body) {
-    return state.eventHandler.receive({
-      id: event.id,
-      name: event.name,
-      payload: event.body as EmitterWebhookEvent["payload"],
-    });
-  }
-
   let payload: EmitterWebhookEvent["payload"];
 
   try {

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -419,7 +419,7 @@ describe("createNodeMiddleware(webhooks)", () => {
   });
 
   test("Handles timeout", async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] });
 
     const webhooks = new Webhooks({
       secret: "mySecret",
@@ -454,7 +454,7 @@ describe("createNodeMiddleware(webhooks)", () => {
   });
 
   test("Handles timeout with error", async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] });
 
     const webhooks = new Webhooks({
       secret: "mySecret",

--- a/test/integration/node-middleware.test.ts
+++ b/test/integration/node-middleware.test.ts
@@ -107,6 +107,53 @@ describe("createNodeMiddleware(webhooks)", () => {
     server.close();
   });
 
+  test("request.body is already an Object and has request.rawBody as Buffer (e.g. GCF)", async () => {
+    expect.assertions(3);
+
+    const webhooks = new Webhooks({
+      secret: "mySecret",
+    });
+    const dataChunks: any[] = [];
+    const middleware = createNodeMiddleware(webhooks);
+
+    const server = createServer((req, res) => {
+      req.once("data", (chunk) => dataChunks.push(chunk));
+      req.once("end", () => {
+        // @ts-expect-error - TS2339: Property 'rawBody' does not exist on type 'IncomingMessage'.
+        req.rawBody = Buffer.concat(dataChunks);
+        // @ts-expect-error - TS2339: Property 'body' does not exist on type 'IncomingMessage'.
+        req.body = JSON.parse(req.rawBody);
+        middleware(req, res);
+      });
+    }).listen();
+
+    webhooks.on("push", (event) => {
+      expect(event.id).toBe("123e4567-e89b-12d3-a456-426655440000");
+    });
+
+    // @ts-expect-error complains about { port } although it's included in returned AddressInfo interface
+    const { port } = server.address();
+
+    const response = await fetch(
+      `http://localhost:${port}/api/github/webhooks`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-GitHub-Delivery": "123e4567-e89b-12d3-a456-426655440000",
+          "X-GitHub-Event": "push",
+          "X-Hub-Signature-256": signatureSha256,
+        },
+        body: pushEventPayload,
+      },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(await response.text()).toEqual("ok\n");
+
+    server.close();
+  });
+
   test("Handles invalid Content-Type", async () => {
     const webhooks = new Webhooks({
       secret: "mySecret",


### PR DESCRIPTION
Resolves #935 

As explained in #935 in gcf the payload is already deserialized to be an object, resulting that the payload can not be verified.

Can this be please fast-tracked?

@wolfy1339 
@gr2m 

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

