### PR TITLE
fix: Get raw body properly on Vercel

### DIFF
--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -29,6 +29,7 @@ export async function getPayload(request: IncomingMessage): Promise<string> {
     ) {
       // The body is already an Object and rawBody is a Buffer (e.g. GCF)
       return request.rawBody.toString("utf8");
+    // request is a readable stream (e.g. vercel)
     } else if(Symbol.asyncIterator in request || Symbol.iterator in request) {
       const buf = await buffer(req);
       return buf.toString('utf8');


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #961

----

### Before the change?

Bodies were not of type string on Vercel, which broke Probot.

### After the change?

Bodies are now read as string.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

(Tests will be added later)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

