### PR TITLE
fix(deps): update `@octokit/webhooks-methods`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
-        "@octokit/webhooks-methods": "^4.0.0",
+        "@octokit/webhooks-methods": "^4.1.0",
         "@octokit/webhooks-types": "7.3.2",
         "aggregate-error": "^3.1.0"
       },
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/@octokit/webhooks-methods": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.0.0.tgz",
-      "integrity": "sha512-M8mwmTXp+VeolOS/kfRvsDdW+IO0qJ8kYodM/sAysk093q6ApgmBXwK1ZlUvAwXVrp/YVHp6aArj4auAxUAOFw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+      "integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
       "engines": {
         "node": ">= 18"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@octokit/request-error": "^5.0.0",
-    "@octokit/webhooks-methods": "^4.0.0",
+    "@octokit/webhooks-methods": "^4.1.0",
     "@octokit/webhooks-types": "7.3.2",
     "aggregate-error": "^3.1.0"
   },


### PR DESCRIPTION
This allows us to get errors when users pass payloads as objects and aren't using TypeScript

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Object payloads could be passed to the different methods with no error when not using TypeScript

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Object payloads will trigger an error at runtime if passed

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

