### PR TITLE
fix: explicitly check that `request.body` is a string

### DIFF
--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -12,7 +12,7 @@ import AggregateError from "aggregate-error";
 type IncomingMessage = any;
 
 export function getPayload(request: IncomingMessage): Promise<string> {
-  if ("body" in request) {
+  if (request.body) {
     if (
       typeof request.body === "object" &&
       "rawBody" in request &&

--- a/src/middleware/node/get-payload.ts
+++ b/src/middleware/node/get-payload.ts
@@ -12,18 +12,16 @@ import AggregateError from "aggregate-error";
 type IncomingMessage = any;
 
 export function getPayload(request: IncomingMessage): Promise<string> {
-  if (request.body) {
-    if (
-      typeof request.body === "object" &&
-      "rawBody" in request &&
-      request.rawBody instanceof Buffer
-    ) {
-      // The body is already an Object and rawBody is a Buffer (e.g. GCF)
-      return Promise.resolve(request.rawBody.toString("utf8"));
-    } else {
-      // The body is a String (e.g. Lambda)
-      return Promise.resolve(request.body);
-    }
+  if (
+    typeof request.body === "object" &&
+    "rawBody" in request &&
+    request.rawBody instanceof Buffer
+  ) {
+    // The body is already an Object and rawBody is a Buffer (e.g. GCF)
+    return Promise.resolve(request.rawBody.toString("utf8"));
+  } else if (typeof request.body === "string") {
+    // The body is a String (e.g. Lambda)
+    return Promise.resolve(request.body);
   }
 
   // We need to load the payload from the request (normal case of Node.js server)

--- a/test/integration/get-payload.test.ts
+++ b/test/integration/get-payload.test.ts
@@ -74,4 +74,19 @@ describe("getPayload", () => {
 
     expect(await promise).toEqual("foo");
   });
+
+  it("resolves with a string if the body key of the request is defined but value is undefined", async () => {
+    const request = new EventEmitter();
+    // @ts-ignore body is not part of EventEmitter, which we are using
+    // to mock the request object
+    request.body = undefined;
+
+    const promise = getPayload(request);
+
+    // we emit data, to ensure that the body attribute is preferred
+    request.emit("data", "bar");
+    request.emit("end");
+
+    expect(await promise).toEqual("bar");
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1009 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* I am reverting a conditional that changes the handling of `request.body` that was made within v12.0.10. This broke webhooks for libraries that define the request `body` key, if `body` is undefined such as `@fastify/middie` rather than not including the `body` property like `node:http` and `express`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `getPayload()` will resolve with a string rather than the undefined if the request body key is defined but has a value undefined.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

UPDATE: This may be being fixed upstream within `@fastify/middie`, if attempting to reproduce this bug please use a Middie <=8.3.0. I think the `@octokit/webhooks` patch should still be completed as this could be quite difficult to diagnose if the user is on a <=8.3.0 of Middie or if they have constraints for upgrading it.
