### PR TITLE
fix: make verifyAndReceive accept a string name.

### DIFF
--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -2,8 +2,6 @@
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-import type { WebhookEventName } from "../../generated/webhook-identifiers.js";
-
 import type { Webhooks } from "../../index.js";
 import type { WebhookEventHandlerError } from "../../types.js";
 import type { MiddlewareOptions } from "./types.js";
@@ -75,7 +73,7 @@ export async function middleware(
     return true;
   }
 
-  const eventName = request.headers["x-github-event"] as WebhookEventName;
+  const eventName = request.headers["x-github-event"] as string;
   const signatureSHA256 = request.headers["x-hub-signature-256"] as string;
   const id = request.headers["x-github-delivery"] as string;
 
@@ -95,7 +93,7 @@ export async function middleware(
 
     await webhooks.verifyAndReceive({
       id: id,
-      name: eventName as any,
+      name: eventName,
       payload,
       signature: signatureSHA256,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type EmitterWebhookEvent<
 
 export type EmitterWebhookEventWithStringPayloadAndSignature = {
   id: string;
-  name: WebhookEventName;
+  name: string;
   payload: string;
   signature: string;
 };


### PR DESCRIPTION
As naturally comes from the relevant HTTP header.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves the easy half of #1055

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Callers have to do an unchecked cast from `string` to either `any` or the unexported `WebhookEventName` type.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Callers can pass the HTTP header directly into `verifyAndReceive()`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
Kinda: I removed the cast from the middleware, so it'll break if the stricter type is re-introduced.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
This type constraint doesn't seem to have been documented.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

