### PR TITLE
Update `createNodeMiddleware()` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ The middleware returned from `createNodeMiddleware` can also serve as an
         </em>
       </td>
       <td>
-        Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>. Set this to EXACTLY "/" if you want to use the middleware as a custom handler in your own routers
+        Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>. Set this to EXACTLY `"/"` if you want to use the middleware as a custom handler in your own routers
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ The middleware returned from `createNodeMiddleware` can also serve as an
         </em>
       </td>
       <td>
-        Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>.
+        Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>. Set this to EXACTLY "/" if you want to use the middleware as a custom handler in your own routers
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Update `createNodeMiddleware()` - `path` option documentation, to reflect exact setting of value for custom routing options

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
* Documentation does not *fully* reflect the correct behavior of `path` in `createNodeMiddleware()`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* Documentation updated, informing users that setting the `path` value to exactly `"/"` enables the created middleware to be used as a handler

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features) *[No Changes]*
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

