### PR TITLE
fix(deps): bump Octokit deps to fix Deno compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-webhooks-types": "8.5.1",
-        "@octokit/request-error": "^6.0.1",
+        "@octokit/request-error": "^6.1.6",
         "@octokit/webhooks-methods": "^5.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@octokit/openapi-webhooks-types": "8.5.1",
-    "@octokit/request-error": "^6.0.1",
+    "@octokit/request-error": "^6.1.6",
     "@octokit/webhooks-methods": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/octokit/octokit.js/issues/2762#issuecomment-2486997620

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Types would include a reference to `@types/node` even though there is nothing using Node specific APIs in the types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Update `@octokit/types` to make sure types are platform agnostic
* Update all Octokit dependencies to their latest version to ensure we pull in the latest version of `@octokit/types`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

