### PR TITLE
fix: add `./types` entrypoint

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -68,6 +68,9 @@ async function main() {
             // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
             default: "./dist-bundle/index.js",
           },
+          "./types": {
+            types: "./dist-types/types.d.ts"
+          },
         },
         source: "dist-src/index.js",
         sideEffects: false,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -69,7 +69,7 @@ async function main() {
             default: "./dist-bundle/index.js",
           },
           "./types": {
-            types: "./dist-types/types.d.ts"
+            types: "./dist-types/types.d.ts",
           },
         },
         source: "dist-src/index.js",


### PR DESCRIPTION
Add back types import that was lost in the transition to ESM

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Part of https://github.com/octokit/webhooks.js/issues/1055

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Previously any file was available to import when the package was CJS, when we switched to ESM you couldn't use that import path anymore.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds a `/type` entrypoint to allow importing some "internal" types

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

