### PR TITLE
docs: add `createWebMiddleware()` & update `event-handler` to reflect ESM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ source.onmessage = (event) => {
 8. [webhooks.onError()](#webhooksonerror)
 9. [webhooks.removeListener()](#webhooksremovelistener)
 10. [createNodeMiddleware()](#createnodemiddleware)
-11. [Webhook events](#webhook-events)
-12. [emitterEventNames](#emittereventnames)
+11. [createWebMiddleware()](#createwebmiddleware)
+12. [Webhook events](#webhook-events)
+13. [emitterEventNames](#emittereventnames)
 
 ### Constructor
 

--- a/README.md
+++ b/README.md
@@ -570,6 +570,63 @@ Used for internal logging. Defaults to [`console`](https://developer.mozilla.org
   <tbody>
 </table>
 
+### createWebMiddleware()
+
+```js
+import { Webhooks, createWebMiddleware } from "@octokit/webhooks";
+
+const webhooks = new Webhooks({
+  secret: "mysecret",
+});
+
+const middleware = createWebMiddleware(webhooks, { path: "/webhooks" });
+
+// Example usage in Deno
+Deno.serve({ port: 3000 }, middleware);
+```
+
+The middleware returned from `createWebMiddleware` can also be used in serverless environments like AWS Lambda, Cloudflare Workers, and Vercel.
+
+<table width="100%">
+  <tbody valign="top">
+    <tr>
+      <td>
+        <code>webhooks</code>
+        <em>
+          Webhooks instance
+        </em>
+      </td>
+      <td>
+        <strong>Required.</strong>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>path</code>
+        <em>
+          string
+        </em>
+      </td>
+      <td>
+        Custom path to match requests against. Defaults to <code>/api/github/webhooks</code>.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>log</code>
+        <em>
+          object
+        </em>
+      </td>
+      <td>
+
+Used for internal logging. Defaults to [`console`](https://developer.mozilla.org/en-US/docs/Web/API/console) with `debug` and `info` doing nothing.
+
+</td>
+    </tr>
+  <tbody>
+</table>
+
 ### Webhook events
 
 See the full list of [event types with example payloads](https://docs.github.com/developers/webhooks-and-events/webhook-events-and-payloads/).

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "node scripts/build.mjs && tsc -p tsconfig.json",
     "generate-types": "node --loader=ts-node/esm scripts/generate-types.ts",
-    "lint": "prettier --check 'src/**/*.{ts,json}' 'scripts/**/*' 'test/**/*.ts' README.md package.json",
-    "lint:fix": "prettier --write 'src/**/*.{ts,json}' 'scripts/**/*' 'test/**/*.ts' README.md package.json",
+    "lint": "prettier --check 'src/**/*.{ts,json}' 'scripts/**/*' 'test/**/*.ts' README.md package.json 'src/event-handler/README.md'",
+    "lint:fix": "prettier --write 'src/**/*.{ts,json}' 'scripts/**/*' 'test/**/*.ts' README.md package.json 'src/event-handler/README.md'",
     "pretest": "npm run -s lint",
     "test": "vitest",
     "validate:ts": "tsc --noEmit --noImplicitAny --target es2023 --esModuleInterop --moduleResolution node16 --module node16 --allowImportingTsExtensions test/typescript-validate.ts"

--- a/src/event-handler/README.md
+++ b/src/event-handler/README.md
@@ -5,21 +5,23 @@ If you implement the route to receive webhook events from GitHub yourself then y
 ## Example
 
 ```js
-const { createEventHandler } = require('@octokit/webhooks')
+import { createEventHandler } from "@octokit/webhooks";
 const eventHandler = createEventHandler({
-  async transform (event) {
+  async transform(event) {
     // optionally transform passed event before handlers are called
-    return event
-  }
-})
-eventHandler.on('installation', asyncInstallationHook)
+    return event;
+  },
+});
+eventHandler.on("installation", asyncInstallationHook);
 
 // put this inside your webhooks route handler
-eventHandler.receive({
-  id: request.headers['x-github-delivery'],
-  name: request.headers['x-github-event'],
-  payload: request.body
-}).catch(handleErrorsFromHooks)
+eventHandler
+  .receive({
+    id: request.headers["x-github-delivery"],
+    name: request.headers["x-github-event"],
+    payload: request.body,
+  })
+  .catch(handleErrorsFromHooks);
 ```
 
 ## 🚨 Verify events
@@ -27,11 +29,11 @@ eventHandler.receive({
 If you receive events through a publicly accessible URL, make sure to verify that the event request is coming from GitHub:
 
 ```js
-import { verify } from '@octokit/webhooks';
-const secret = 'mysecret'
+import { verify } from "@octokit/webhooks";
+const secret = "mysecret";
 
-if (!verify(secret, request.payload, request.headers['x-hub-signature'])) {
-  throw new Error('Signature does not match event payload & secret')
+if (!verify(secret, request.payload, request.headers["x-hub-signature-256"])) {
+  throw new Error("Signature does not match event payload & secret");
 }
 ```
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Docs were missing the `createWebMiddleware()` function
* Docs for the `event-handler` module didn't reflect ESM usage

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Docs now include `createWebMiddleware()`
* Docs for `event-handler` contain the correct usage instructions for ESM

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

