### PR TITLE
Use ts imports in src

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,20 @@ name: Test
       - opened
       - synchronize
 jobs:
+  test-building:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: lts/*
+      - run: npm ci
+      - run: npm run build
+
   test_matrix:
+    needs:
+      - test-building
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,9 +38,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+    
   test:
     runs-on: ubuntu-latest
-    needs: test_matrix
+    needs:
+      - test-building
+      - test_matrix
     steps:
       - run: exit 1
         if: ${{ needs.test_matrix.result != 'success' }}

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -2,7 +2,7 @@
 
 import { strict as assert } from "node:assert";
 import * as fs from "node:fs";
-import type { OpenAPI3, OperationObject, PathItemObject } from "./types.js";
+import type { OpenAPI3, OperationObject, PathItemObject } from "./types.ts";
 import { format } from "prettier";
 
 const schema = (await import("@octokit/openapi-webhooks")).schemas[
@@ -115,7 +115,7 @@ const run = async () => {
     "// THIS FILE IS GENERATED - DO NOT EDIT DIRECTLY",
     "// make edits in scripts/generate-types.ts",
     "",
-    "import type { WebhookEventDefinition } from '../types.js';",
+    "import type { WebhookEventDefinition } from '../types.ts';",
     "",
     "export type EventPayloadMap = {",
     ...Object.keys(eventsMap).map(

--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "../createLogger.js";
+import { createLogger } from "../createLogger.ts";
 import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
@@ -7,14 +7,14 @@ import type {
   State,
   WebhookError,
   WebhookEventHandlerError,
-} from "../types.js";
+} from "../types.ts";
 import {
   receiverOn as on,
   receiverOnAny as onAny,
   receiverOnError as onError,
-} from "./on.js";
-import { receiverHandle as receive } from "./receive.js";
-import { removeListener } from "./remove-listener.js";
+} from "./on.ts";
+import { receiverHandle as receive } from "./receive.ts";
+import { removeListener } from "./remove-listener.ts";
 
 export interface EventHandler<TTransformed = unknown> {
   on<E extends EmitterWebhookEventName>(

--- a/src/event-handler/on.ts
+++ b/src/event-handler/on.ts
@@ -1,10 +1,10 @@
-import { emitterEventNames } from "../generated/webhook-names.js";
+import { emitterEventNames } from "../generated/webhook-names.ts";
 import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
   State,
   WebhookEventHandlerError,
-} from "../types.js";
+} from "../types.ts";
 
 function handleEventHandlers(
   state: State,

--- a/src/event-handler/receive.ts
+++ b/src/event-handler/receive.ts
@@ -4,8 +4,8 @@ import type {
   WebhookError,
   WebhookEventName,
   WebhookEventHandlerError,
-} from "../types.js";
-import { wrapErrorHandler } from "./wrap-error-handler.js";
+} from "../types.ts";
+import { wrapErrorHandler } from "./wrap-error-handler.ts";
 
 type EventAction = Extract<
   EmitterWebhookEvent["payload"],

--- a/src/event-handler/remove-listener.ts
+++ b/src/event-handler/remove-listener.ts
@@ -1,4 +1,4 @@
-import type { EmitterWebhookEventName, State } from "../types.js";
+import type { EmitterWebhookEventName, State } from "../types.ts";
 
 export function removeListener(
   state: State,

--- a/src/generated/webhook-identifiers.ts
+++ b/src/generated/webhook-identifiers.ts
@@ -1,7 +1,7 @@
 // THIS FILE IS GENERATED - DO NOT EDIT DIRECTLY
 // make edits in scripts/generate-types.ts
 
-import type { WebhookEventDefinition } from "../types.js";
+import type { WebhookEventDefinition } from "../types.ts";
 
 export type EventPayloadMap = {
   branch_protection_configuration:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-import { createLogger } from "./createLogger.js";
+import { createLogger } from "./createLogger.ts";
 import {
   createEventHandler,
   type EventHandler,
-} from "./event-handler/index.js";
+} from "./event-handler/index.ts";
 import { sign, verify } from "@octokit/webhooks-methods";
-import { verifyAndReceive } from "./verify-and-receive.js";
+import { verifyAndReceive } from "./verify-and-receive.ts";
 import type {
   EmitterWebhookEvent,
   EmitterWebhookEventName,
@@ -15,11 +15,11 @@ import type {
   WebhookError,
   WebhookEventHandlerError,
   EmitterWebhookEventWithStringPayloadAndSignature,
-} from "./types.js";
+} from "./types.ts";
 
-export { createNodeMiddleware } from "./middleware/node/index.js";
-export { createWebMiddleware } from "./middleware/web/index.js";
-export { emitterEventNames } from "./generated/webhook-names.js";
+export { createNodeMiddleware } from "./middleware/node/index.ts";
+export { createWebMiddleware } from "./middleware/web/index.ts";
+export { emitterEventNames } from "./generated/webhook-names.ts";
 
 // U holds the return value of `transform` function in Options
 class Webhooks<TTransformed = unknown> {

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -1,7 +1,7 @@
-import { createLogger } from "../../createLogger.js";
-import type { Webhooks } from "../../index.js";
-import { middleware } from "./middleware.js";
-import type { MiddlewareOptions } from "../types.js";
+import { createLogger } from "../../createLogger.ts";
+import type { Webhooks } from "../../index.ts";
+import { middleware } from "./middleware.ts";
+import type { MiddlewareOptions } from "../types.ts";
 
 export function createNodeMiddleware(
   webhooks: Webhooks,

--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -2,12 +2,12 @@
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-import type { Webhooks } from "../../index.js";
-import type { WebhookEventHandlerError } from "../../types.js";
-import type { MiddlewareOptions } from "../types.js";
-import { getMissingHeaders } from "./get-missing-headers.js";
-import { getPayload } from "./get-payload.js";
-import { onUnhandledRequestDefault } from "./on-unhandled-request-default.js";
+import type { Webhooks } from "../../index.ts";
+import type { WebhookEventHandlerError } from "../../types.ts";
+import type { MiddlewareOptions } from "../types.ts";
+import { getMissingHeaders } from "./get-missing-headers.ts";
+import { getPayload } from "./get-payload.ts";
+import { onUnhandledRequestDefault } from "./on-unhandled-request-default.ts";
 
 export async function middleware(
   webhooks: Webhooks,

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "../createLogger.js";
+import type { Logger } from "../createLogger.ts";
 
 export type MiddlewareOptions = {
   path?: string;

--- a/src/middleware/web/index.ts
+++ b/src/middleware/web/index.ts
@@ -1,7 +1,7 @@
-import { createLogger } from "../../createLogger.js";
-import type { Webhooks } from "../../index.js";
-import { middleware } from "./middleware.js";
-import type { MiddlewareOptions } from "../types.js";
+import { createLogger } from "../../createLogger.ts";
+import type { Webhooks } from "../../index.ts";
+import { middleware } from "./middleware.ts";
+import type { MiddlewareOptions } from "../types.ts";
 
 export function createWebMiddleware(
   webhooks: Webhooks,

--- a/src/middleware/web/middleware.ts
+++ b/src/middleware/web/middleware.ts
@@ -1,11 +1,11 @@
-import type { WebhookEventName } from "../../generated/webhook-identifiers.js";
+import type { WebhookEventName } from "../../generated/webhook-identifiers.ts";
 
-import type { Webhooks } from "../../index.js";
-import type { WebhookEventHandlerError } from "../../types.js";
-import type { MiddlewareOptions } from "../types.js";
-import { getMissingHeaders } from "./get-missing-headers.js";
-import { getPayload } from "./get-payload.js";
-import { onUnhandledRequestDefault } from "./on-unhandled-request-default.js";
+import type { Webhooks } from "../../index.ts";
+import type { WebhookEventHandlerError } from "../../types.ts";
+import type { MiddlewareOptions } from "../types.ts";
+import { getMissingHeaders } from "./get-missing-headers.ts";
+import { getPayload } from "./get-payload.ts";
+import { onUnhandledRequestDefault } from "./on-unhandled-request-default.ts";
 
 export async function middleware(
   webhooks: Webhooks,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import type { RequestError } from "@octokit/request-error";
 import type { webhooks as OpenAPIWebhooks } from "@octokit/openapi-webhooks-types";
-import type { EventPayloadMap } from "./generated/webhook-identifiers.js";
-import type { Logger } from "./createLogger.js";
-import type { EventHandler } from "./event-handler/index.js";
-import type { emitterEventNames } from "./generated/webhook-names.js";
+import type { EventPayloadMap } from "./generated/webhook-identifiers.ts";
+import type { Logger } from "./createLogger.ts";
+import type { EventHandler } from "./event-handler/index.ts";
+import type { emitterEventNames } from "./generated/webhook-names.ts";
 
 export type WebhookEventName = keyof EventPayloadMap;
 export type ExtractEvents<TEventName> =

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -5,8 +5,8 @@ import type {
   EmitterWebhookEventWithStringPayloadAndSignature,
   State,
   WebhookError,
-} from "./types.js";
-import type { EventHandler } from "./event-handler/index.js";
+} from "./types.ts";
+import type { EventHandler } from "./event-handler/index.ts";
 
 export async function verifyAndReceive(
   state: State & { secret: string; eventHandler: EventHandler<unknown> },

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -1,4 +1,4 @@
-import { WebhookEventDefinition } from "../../src/types";
+import type { WebhookEventDefinition } from "../../src/types.ts";
 import pushEvent from "./push-payload.json";
 import installationCreatedEvent from "./installation-created-payload.json";
 import installationDeletedEvent from "./installation-deleted-payload.json";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     }
   },
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "declaration": true,
     "outDir": "pkg/dist-types",


### PR DESCRIPTION
Splitting up my refactor PR into multiple PRs so that it can be easier reviewed.

This PR changes the imports to .ts files in the src folder. 

With this, you can also test the code in deno. Also it seems that --experimental-strip-types can work better with that on node24. 