### PR TITLE
feat: add new `verifyAndParse()` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type {
   WebhookEventHandlerError,
   EmitterWebhookEventWithStringPayloadAndSignature,
 } from "./types.ts";
+import { verifyAndParse } from "./verify-and-parse.ts";
 
 export { createNodeMiddleware } from "./middleware/node/index.ts";
 export { createWebMiddleware } from "./middleware/web/index.ts";
@@ -47,6 +48,9 @@ class Webhooks<TTransformed = unknown> {
   public verifyAndReceive: (
     options: EmitterWebhookEventWithStringPayloadAndSignature,
   ) => Promise<void>;
+  verifyAndParse: (
+    event: EmitterWebhookEventWithStringPayloadAndSignature,
+  ) => Promise<EmitterWebhookEvent | WebhookError>;
 
   constructor(options: Options<TTransformed> & { secret: string }) {
     if (!options || !options.secret) {
@@ -73,6 +77,15 @@ class Webhooks<TTransformed = unknown> {
     this.removeListener = state.eventHandler.removeListener;
     this.receive = state.eventHandler.receive;
     this.verifyAndReceive = verifyAndReceive.bind(null, state);
+    this.verifyAndParse = async (
+      event: EmitterWebhookEventWithStringPayloadAndSignature,
+    ) => {
+      return verifyAndParse(
+        state.secret,
+        event,
+        state.additionalSecrets,
+      ) as Promise<EmitterWebhookEvent | WebhookError>;
+    };
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,11 +80,7 @@ class Webhooks<TTransformed = unknown> {
     this.verifyAndParse = async (
       event: EmitterWebhookEventWithStringPayloadAndSignature,
     ) => {
-      return verifyAndParse(
-        state.secret,
-        event,
-        state.additionalSecrets,
-      );
+      return verifyAndParse(state.secret, event, state.additionalSecrets);
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ class Webhooks<TTransformed = unknown> {
         state.secret,
         event,
         state.additionalSecrets,
-      ) as Promise<EmitterWebhookEvent | WebhookError>;
+      );
     };
   }
 }

--- a/src/verify-and-parse.ts
+++ b/src/verify-and-parse.ts
@@ -1,0 +1,44 @@
+import { verifyWithFallback } from "@octokit/webhooks-methods";
+
+import type {
+  EmitterWebhookEvent,
+  EmitterWebhookEventWithStringPayloadAndSignature,
+  WebhookError,
+} from "./types.ts";
+
+export async function verifyAndParse(
+  secret: string,
+  event: EmitterWebhookEventWithStringPayloadAndSignature,
+  additionalSecrets?: string[] | undefined,
+): Promise<EmitterWebhookEvent | WebhookError> {
+  // verify will validate that the secret is not undefined
+  const matchesSignature = await verifyWithFallback(
+    secret,
+    event.payload,
+    event.signature,
+    additionalSecrets,
+  ).catch(() => false);
+
+  if (!matchesSignature) {
+    const error = new Error(
+      "[@octokit/webhooks] signature does not match event payload and secret",
+    );
+
+    return Object.assign(error, { event, status: 400 }) as WebhookError;
+  }
+
+  let payload: EmitterWebhookEvent["payload"];
+  try {
+    payload = JSON.parse(event.payload);
+  } catch (error: any) {
+    error.message = "Invalid JSON";
+    error.status = 400;
+    throw new AggregateError([error], error.message);
+  }
+
+  return {
+    id: event.id,
+    name: event.name,
+    payload,
+  } as EmitterWebhookEvent;
+}

--- a/src/verify-and-receive.ts
+++ b/src/verify-and-receive.ts
@@ -1,10 +1,7 @@
-import { verifyWithFallback } from "@octokit/webhooks-methods";
-
+import { verifyAndParse } from "./verify-and-parse.ts";
 import type {
-  EmitterWebhookEvent,
   EmitterWebhookEventWithStringPayloadAndSignature,
   State,
-  WebhookError,
 } from "./types.ts";
 import type { EventHandler } from "./event-handler/index.ts";
 
@@ -12,36 +9,7 @@ export async function verifyAndReceive(
   state: State & { secret: string; eventHandler: EventHandler<unknown> },
   event: EmitterWebhookEventWithStringPayloadAndSignature,
 ): Promise<void> {
-  // verify will validate that the secret is not undefined
-  const matchesSignature = await verifyWithFallback(
-    state.secret,
-    event.payload,
-    event.signature,
-    state.additionalSecrets,
-  ).catch(() => false);
-
-  if (!matchesSignature) {
-    const error = new Error(
-      "[@octokit/webhooks] signature does not match event payload and secret",
-    );
-
-    return state.eventHandler.receive(
-      Object.assign(error, { event, status: 400 }) as WebhookError,
-    );
-  }
-
-  let payload: EmitterWebhookEvent["payload"];
-  try {
-    payload = JSON.parse(event.payload);
-  } catch (error: any) {
-    error.message = "Invalid JSON";
-    error.status = 400;
-    throw new AggregateError([error], error.message);
-  }
-
-  return state.eventHandler.receive({
-    id: event.id,
-    name: event.name,
-    payload,
-  } as EmitterWebhookEvent);
+  return state.eventHandler.receive(
+    await verifyAndParse(state.secret, event, state.additionalSecrets),
+  );
 }

--- a/test/integration/smoke.test.ts
+++ b/test/integration/smoke.test.ts
@@ -24,6 +24,7 @@ it("check exports of @octokit/webhooks", () => {
   assert(typeof api.removeListener === "function");
   assert(typeof api.receive === "function");
   assert(typeof api.verifyAndReceive === "function");
+  assert(typeof api.verifyAndParse === "function");
   assert(typeof api.onAny === "function");
   assert(warned === false);
 

--- a/test/integration/webhooks.test.ts
+++ b/test/integration/webhooks.test.ts
@@ -93,7 +93,7 @@ describe("Webhooks", () => {
       signature: await sign(secret, pushEventPayloadString),
     });
     assert(typeof event === "object");
-    deepEqual(event,{
+    deepEqual(event, {
       name: "push",
       id: "1",
       payload: JSON.parse(pushEventPayloadString),

--- a/test/integration/webhooks.test.ts
+++ b/test/integration/webhooks.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, assert } from "../testrunner.ts";
+import { describe, it, assert, deepEqual } from "../testrunner.ts";
 import { readFileSync } from "node:fs";
 import { sign } from "@octokit/webhooks-methods";
 
 import { Webhooks } from "../../src/index.ts";
-import { expect } from "vitest";
 
 const pushEventPayloadString = readFileSync(
   "test/fixtures/push-payload.json",
@@ -94,7 +93,7 @@ describe("Webhooks", () => {
       signature: await sign(secret, pushEventPayloadString),
     });
     assert(typeof event === "object");
-    expect(event).toEqual({
+    deepEqual(event,{
       name: "push",
       id: "1",
       payload: JSON.parse(pushEventPayloadString),

--- a/test/testrunner.ts
+++ b/test/testrunner.ts
@@ -40,7 +40,10 @@ if ("Bun" in globalThis) {
   describe = await import("vitest").then((module) => module.describe);
   it = await import("vitest").then((module) => module.it);
   assert = await import("vitest").then((module) => module.assert);
-  deepEqual = await import("vitest").then((module) => (expected: any, actual: any) => module.expect(actual).toEqual(expected));
+  deepEqual = await import("vitest").then(
+    (module) => (expected: any, actual: any) =>
+      module.expect(actual).toEqual(expected),
+  );
 } else {
   const nodeTest = await import("node:test");
   const nodeAssert = await import("node:assert");

--- a/test/testrunner.ts
+++ b/test/testrunner.ts
@@ -13,6 +13,11 @@ if ("Bun" in globalThis) {
   assert = function assert(value: unknown, message?: string) {
     return globalThis.Bun.jest(caller()).expect(value, message);
   };
+  deepEqual = function deepEqual(expected: any, actual: any, message?: string) {
+    return globalThis.Bun.jest(caller())
+      .expect(actual)
+      .toEqual(expected, message);
+  };
   /** Retrieve caller test file. */
   function caller() {
     const Trace = Error as unknown as {

--- a/test/testrunner.ts
+++ b/test/testrunner.ts
@@ -2,7 +2,7 @@ declare global {
   var Bun: any;
 }
 
-let describe: Function, it: Function, assert: Function;
+let describe: Function, it: Function, assert: Function, deepEqual: Function;
 if ("Bun" in globalThis) {
   describe = function describe(name: string, fn: Function) {
     return globalThis.Bun.jest(caller()).describe(name, fn);
@@ -35,10 +35,12 @@ if ("Bun" in globalThis) {
   describe = nodeTest.describe;
   it = nodeTest.it;
   assert = nodeAssert.strict;
+  deepEqual = nodeAssert.deepStrictEqual;
 } else if (process.env.VITEST_WORKER_ID) {
   describe = await import("vitest").then((module) => module.describe);
   it = await import("vitest").then((module) => module.it);
   assert = await import("vitest").then((module) => module.assert);
+  deepEqual = await import("vitest").then((module) => (expected: any, actual: any) => module.expect(actual).toEqual(expected));
 } else {
   const nodeTest = await import("node:test");
   const nodeAssert = await import("node:assert");
@@ -46,6 +48,7 @@ if ("Bun" in globalThis) {
   describe = nodeTest.describe;
   it = nodeTest.it;
   assert = nodeAssert.strict;
+  deepEqual = nodeAssert.deepStrictEqual;
 }
 
-export { describe, it, assert };
+export { describe, it, assert, deepEqual };


### PR DESCRIPTION
This method is almost identical to `verifyAndReceive()`, the difference being that this function won't trigger the event handler, so it can be executed at a later time.

The code has been refactored so that this function is used internally to remove duplication.

Fixes #379

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Users could not simply get an `EmitterWebhookEvent` object, the included functions would fire the event handler for webhook events

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Users can now get an `EmitterWebhookEvent` object without the event handler being utilised. This is especially useful for serverless platforms

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

