### PR TITLE
test: fix TypeScript validation tests errors

### DIFF
--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -192,7 +192,7 @@ export default async function () {
     console.log(error.event.foo);
     const [firstError] = Array.from(error.errors);
     console.log(firstError.status);
-    console.log(firstError?.request.headers);
+    console.log(firstError?.request?.headers);
     console.log(firstError.request);
   });
 

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -173,6 +173,12 @@ export default async function () {
     console.log(event.foo);
   });
 
+  webhooks.onAny((event) => {
+    // Make sure that `TTransformed` is properly passed to `onAny`
+    // foo is set by options.transform
+    console.log(event.foo);
+  });
+
   // @ts-expect-error TS2345:
   //  Argument of type '"does_not_exist"' is not assignable to parameter of type ...
   webhooks.on("does_not_exist", (what) => {
@@ -182,6 +188,8 @@ export default async function () {
 
   webhooks.onError((error) => {
     console.log(error.event.name);
+    // Make sure that `TTransformed` is properly passed to `onError`
+    console.log(error.event.foo);
     const [firstError] = Array.from(error.errors);
     console.log(firstError.status);
     console.log(firstError?.request.headers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "./node_modules/@octokit/tsconfig/tsconfig.json",
   "include": ["src/**/*"],
-  "ts-node": {
-    "compilerOptions": {
-      "allowImportingTsExtensions": true,
-      "verbatimModuleSyntax": false
-    }
-  },
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,


### PR DESCRIPTION
Ever since new events were added in #1189, the validation tests have started failing

I added 2 missing tests that were not added in https://github.com/octokit/webhooks.js/pull/924

These are the errors:
```
Property 'foo' does not exist on type 'EmitterWebhookEvent'.
  Property 'foo' does not exist on type 'BaseWebhookEvent<"branch_protection_configuration">'.

Expression produces a union type that is too complex to represent.

Property 'foo' does not exist on type 'BaseWebhookEvent<"branch_protection_configuration"> | BaseWebhookEvent<"branch_protection_rule"> | BaseWebhookEvent<"check_run"> | ... 320 more ... | (BaseWebhookEvent<...> & { ...; })'.
  Property 'foo' does not exist on type 'BaseWebhookEvent<"branch_protection_configuration">'.
```